### PR TITLE
Generate_Conceptual_Help: uses the correct path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     DscResource.DocGenerator:
       - 'Task.*'
   ```
+  
+### Fixed
+
+- Fixes the build task `Generate_Conceptual_Help` to use the correct
+  module version folder name for the built module path ([issue #17](https://github.com/dsccommunity/DscResource.DocGenerator/issues/17)).
 
 ## [0.3.0] - 2020-02-11
 

--- a/README.md
+++ b/README.md
@@ -88,3 +88,7 @@ BuildWorkflow:
     - Create_changelog_release_output
     - Generate_Conceptual_Help
 ```
+
+>**NOTE:** If the module the task is used in is using the project [Sampler's](https://github.com/gaelcolas/Sampler)
+>`build.ps1` then version 0.102.1 of [Sampler](https://github.com/gaelcolas/Sampler)
+>is required.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,6 @@ BuildWorkflow:
     - Generate_Conceptual_Help
 ```
 
->**NOTE:** If the module the task is used in is using the project [Sampler's](https://github.com/gaelcolas/Sampler)
+>**NOTE:** If the task is used in a module that is using the project [Sampler's](https://github.com/gaelcolas/Sampler)
 >`build.ps1` then version 0.102.1 of [Sampler](https://github.com/gaelcolas/Sampler)
 >is required.

--- a/source/tasks/Generate_Conceptual_Help.build.ps1
+++ b/source/tasks/Generate_Conceptual_Help.build.ps1
@@ -83,7 +83,7 @@ param
     ),
 
     [Parameter()]
-    [string]
+    [System.String]
     $ModuleVersion = (property ModuleVersion $(
             try
             {

--- a/source/tasks/Generate_Conceptual_Help.build.ps1
+++ b/source/tasks/Generate_Conceptual_Help.build.ps1
@@ -82,11 +82,11 @@ param
     ),
 
     [Parameter()]
-    [System.String]
-    $ModuleVersionFolder = (property ModuleVersionFolder $(
+    [string]
+    $ModuleVersion = (property ModuleVersion $(
             try
             {
-                (gitversion | ConvertFrom-Json -ErrorAction Stop).MajorMinorPatch
+                (gitversion | ConvertFrom-Json -ErrorAction Stop).NuGetVersionV2
             }
             catch
             {
@@ -106,11 +106,15 @@ task Generate_Conceptual_Help {
         $OutputDirectory = Join-Path -Path $ProjectPath -ChildPath $OutputDirectory
     }
 
+    $ModuleVersionFolder, $PreReleaseString = $ModuleVersion -split '\-', 2
+
     $builtModulePath = Join-Path -Path (Join-Path -Path $OutputDirectory -ChildPath $ProjectName) -ChildPath $ModuleVersionFolder
 
     "`tProject Path            = $ProjectPath"
     "`tProject Name            = $ProjectName"
+    "`tModule Version          = $ModuleVersion"
     "`tModule Version Folder   = $ModuleVersionFolder"
+    "`tPrerelease String       = $PreReleaseString"
     "`tSource Path             = $SourcePath"
     "`tBuilt Module Path       = $builtModulePath"
 

--- a/source/tasks/Generate_Conceptual_Help.build.ps1
+++ b/source/tasks/Generate_Conceptual_Help.build.ps1
@@ -18,10 +18,10 @@
         The path to the source folder name. Defaults to the same path where the
         module manifest is found.
 
-    .PARAMETER ModuleVersion
-        The module version of the build module. Defaults to the semantic version
-        returned by GitVersion. If GitVersion is not present, the default is
-        version '0.0.1'.
+    .PARAMETER ModuleVersionFolder
+        The module version folder name of the build module, e.g. 'MyModule/99.1.1'.
+        Defaults to the property MajorMinorPatch returned by GitVersion. If
+        GitVersion is not present, the parameter defaults to version '0.0.1'.
 
     .PARAMETER BuildInfo
         The build info object from ModuleBuilder. Defaults to an empty hashtable.
@@ -83,14 +83,14 @@ param
 
     [Parameter()]
     [System.String]
-    $ModuleVersion = (property ModuleVersion $(
+    $ModuleVersionFolder = (property ModuleVersionFolder $(
             try
             {
-                (gitversion | ConvertFrom-Json -ErrorAction Stop).InformationalVersion
+                (gitversion | ConvertFrom-Json -ErrorAction Stop).MajorMinorPatch
             }
             catch
             {
-                Write-Verbose "Error attempting to use GitVersion $($_), falling back to default of '0.0.1'."
+                Write-Verbose -Message "Error attempting to use GitVersion $($_), falling back to default of '0.0.1'."
                 '0.0.1'
             }
         )),
@@ -106,11 +106,11 @@ task Generate_Conceptual_Help {
         $OutputDirectory = Join-Path -Path $ProjectPath -ChildPath $OutputDirectory
     }
 
-    $builtModulePath = Join-Path -Path (Join-Path -Path $OutputDirectory -ChildPath $ProjectName) -ChildPath $ModuleVersion
+    $builtModulePath = Join-Path -Path (Join-Path -Path $OutputDirectory -ChildPath $ProjectName) -ChildPath $ModuleVersionFolder
 
     "`tProject Path            = $ProjectPath"
     "`tProject Name            = $ProjectName"
-    "`tModule Version          = $ModuleVersion"
+    "`tModule Version Folder   = $ModuleVersionFolder"
     "`tSource Path             = $SourcePath"
     "`tBuilt Module Path       = $builtModulePath"
 

--- a/source/tasks/Generate_Conceptual_Help.build.ps1
+++ b/source/tasks/Generate_Conceptual_Help.build.ps1
@@ -18,10 +18,11 @@
         The path to the source folder name. Defaults to the same path where the
         module manifest is found.
 
-    .PARAMETER ModuleVersionFolder
-        The module version folder name of the build module, e.g. 'MyModule/99.1.1'.
-        Defaults to the property MajorMinorPatch returned by GitVersion. If
-        GitVersion is not present, the parameter defaults to version '0.0.1'.
+    .PARAMETER ModuleVersion
+        The module version of the build module, e.g. '99.1.1-preview0001'. Defaults
+        to using the value from parent scope, if that is not available it defaults
+        to the property NuGetVersionV2 returned by GitVersion. If GitVersion is not
+        present, the parameter defaults to version '0.0.1'.
 
     .PARAMETER BuildInfo
         The build info object from ModuleBuilder. Defaults to an empty hashtable.

--- a/tests/unit/tasks/Generate_Conceptual_Help.build.Tests.ps1
+++ b/tests/unit/tasks/Generate_Conceptual_Help.build.Tests.ps1
@@ -62,20 +62,24 @@ Describe 'Generate_Conceptual_Help' {
             } -ParameterFilter {
                 $Name -eq 'ModuleVersion'
             }
-        }
 
-        It 'Should run the build task with the correct destination module path and without throwing' {
             $mockTaskParameters = @{
                 ProjectName = 'MyModule'
                 SourcePath = $TestDrive
             }
 
+            $mockExpectedDestinationModulePath = Join-Path -Path $script:projectPath -ChildPath 'output' |
+                Join-Path -ChildPath $mockTaskParameters.ProjectName |
+                    Join-Path -ChildPath '99.1.1'
+        }
+
+        It 'Should run the build task with the correct destination module path and without throwing' {
             {
                 Invoke-Build -Task $buildTaskName -File $script:buildScript.Definition @mockTaskParameters
             } | Should -Not -Throw
 
             Assert-MockCalled -CommandName New-DscResourcePowerShellHelp -ParameterFilter {
-                $DestinationModulePath -eq ('{0}\output\{1}\99.1.1' -f $script:projectPath, $mockTaskParameters.ProjectName)
+                $DestinationModulePath -eq $mockExpectedDestinationModulePath
             } -Exactly -Times 1 -Scope It
         }
     }
@@ -91,6 +95,15 @@ Describe 'Generate_Conceptual_Help' {
                 }
                 '
             }
+
+            $mockTaskParameters = @{
+                ProjectName = 'MyModule'
+                SourcePath = $TestDrive
+            }
+
+            $mockExpectedDestinationModulePath = Join-Path -Path $script:projectPath -ChildPath 'output' |
+                Join-Path -ChildPath $mockTaskParameters.ProjectName |
+                    Join-Path -ChildPath '99.1.1'
         }
 
         It 'Should run the build task with the correct destination module path and without throwing' {
@@ -104,7 +117,7 @@ Describe 'Generate_Conceptual_Help' {
             } | Should -Not -Throw
 
             Assert-MockCalled -CommandName New-DscResourcePowerShellHelp -ParameterFilter {
-                $DestinationModulePath -eq ('{0}\output\{1}\99.1.1' -f $script:projectPath, $mockTaskParameters.ProjectName)
+                $DestinationModulePath -eq $mockExpectedDestinationModulePath
             } -Exactly -Times 1 -Scope It
         }
     }
@@ -115,6 +128,15 @@ Describe 'Generate_Conceptual_Help' {
             Mock -CommandName gitversion -MockWith {
                 throw
             }
+
+            $mockTaskParameters = @{
+                ProjectName = 'MyModule'
+                SourcePath = $TestDrive
+            }
+
+            $mockExpectedDestinationModulePath = Join-Path -Path $script:projectPath -ChildPath 'output' |
+                Join-Path -ChildPath $mockTaskParameters.ProjectName |
+                    Join-Path -ChildPath '0.0.1'
         }
 
         It 'Should run the build task with the correct destination module path and without throwing' {
@@ -128,7 +150,7 @@ Describe 'Generate_Conceptual_Help' {
             } | Should -Not -Throw
 
             Assert-MockCalled -CommandName New-DscResourcePowerShellHelp -ParameterFilter {
-                $DestinationModulePath -eq ('{0}\output\{1}\0.0.1' -f $script:projectPath, $mockTaskParameters.ProjectName)
+                $DestinationModulePath -eq $mockExpectedDestinationModulePath
             } -Exactly -Times 1 -Scope It
         }
     }


### PR DESCRIPTION
# Pull Request

### Pull Request (PR) description
- Fixes the build task `Generate_Conceptual_Help` to use the correct
  module version folder name for the built module path ([issue #17](https://github.com/dsccommunity/DscResource.DocGenerator/issues/17)).

#### This Pull Request (PR) fixes the following issues
- Fixes #17

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (where possible).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.docgenerator/18)
<!-- Reviewable:end -->
