### PR TITLE
Add support for markdown in parameter descriptions (remove from conceptual help)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The build task `Generate_Conceptual_Help` can now remove markdown code
   from the schema MOF parameter descriptions if markdown code is used to
   improve the Wiki documentation.
-  
+
 ## [0.6.1] - 2020-07-01
   
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.1] - 2020-07-01
+### Added
 
+- The build task `Generate_Conceptual_Help` can now remove markdown code
+  from the schema MOF parameter descriptions if markdown code is used to
+  improve the Wiki documentation.
+  
+## [0.6.1] - 2020-07-01
+  
 ### Fixed
 
 - Update README.md with the correct build task name; 'Publish_GitHub_Wiki_Content'.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,9 @@ capture group 1.
 
 Below is some example regular expressions for the most common markdown code.
 
+>**NOTE:** Each regular expression must be able to find multiple matches
+>on the same row.
+
 ```yaml
 DscResource.DocGenerator:
   Generate_Conceptual_Help:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ After the conceptual help has been created, the user can import the module
 and for example run `Get-Help about_UserAccountControl` to get help about
 the DSC resource UserAccountControl.
 
+It is possible to pass a array of regular expressions that should be used
+to parse the parameter descriptions in the schema MOF. The regular expression
+must be written so that the capture group 0 is the full match and the
+capture group 1 is the text that should be kept.
+
 >**NOTE:** This cmdlet does not work on macOS and will throw an error due 
 >to the problem discussed in issue https://github.com/PowerShell/PowerShell/issues/5970
 >and issue https://github.com/PowerShell/MMI/issues/33.
@@ -52,7 +57,8 @@ the DSC resource UserAccountControl.
 <!-- markdownlint-disable MD013 - Line length -->
 ```plaintext
 New-DscResourcePowerShellHelp [-ModulePath] <string> [[-DestinationModulePath] <string>] 
-  [[-OutputPath] <string>] [<CommonParameters>]
+  [[-OutputPath] <string>] [[-MarkdownCodeRegularExpression] <string[]>]
+  [<CommonParameters>]
 ```
 <!-- markdownlint-enable MD013 - Line length -->
 
@@ -70,7 +76,7 @@ New-DscResourcePowerShellHelp -ModulePath '.'
 
 ### `New-DscResourceWikiPage`
 
-Generate documentation that can be manually uploaded to the GitHub repository 
+Generate documentation that can be manually uploaded to the GitHub repository
 Wiki.
 
 #### Syntax
@@ -235,6 +241,28 @@ BuildWorkflow:
     - Generate_Conceptual_Help
 ```
 
+If the schema mof property descriptions contain markdown code then it is
+possible to configure regular expressions to remove the markdown code.
+The regular expressions must be written so that capture group 0 returns 
+the full match and the capture group 1 returns the text that should be kept. 
+For example the regular expression `` \`(.+?)\` `` will find `` `$true` ``
+which will be replaced to `$true` since that is what will returned by capture
+group 1.
+
+Below is some example regular expression for the most comment markdown code.
+
+```yaml
+DscResource.DocGenerator:
+  Generate_Conceptual_Help:
+    MarkdownCodeRegularExpression:
+      - '\`(.+?)\`' # Match inline code-block
+      - '\\(\\)' # Match escaped backslash
+      - '\[[^\[]+\]\((.+?)\)' # Match markdown URL
+      - '_(.+?)_' # Match Italic (underscore)
+      - '\*\*(.+?)\*\*' # Match bold
+      - '\*(.+?)\*' # Match Italic (asterisk)
+```
+
 >**NOTE:** If the task is used in a module that is using the project [Sampler's](https://github.com/gaelcolas/Sampler)
 >`build.ps1` then version 0.102.1 of [Sampler](https://github.com/gaelcolas/Sampler)
 >is required.
@@ -249,6 +277,11 @@ wiki source folder if it exist (`WikiSourceFolderName` defaults to
 if the `Home.md` is present in the folder specified in `WikiSourceFolderName`
 all module version placeholders (`#.#.#`) will be replaced with the built
 module version.
+
+It is possible to use markdown code in the schema MOF parameter descriptions
+if no conceptual help is generated or the generation of conceptual help
+is configured to parse markdown code. See the task [`Generate_Conceptual_Help`](#generate_conceptual_help)
+for more information.
 
 Below is an example how the build task can be used when a repository is
 based on the [Sampler](https://github.com/gaelcolas/Sampler) project.

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ For example the regular expression `` \`(.+?)\` `` will find `` `$true` ``
 which will be replaced to `$true` since that is what will be returned by
 capture group 1.
 
-Below is some example regular expression for the most comment markdown code.
+Below is some example regular expressions for the most common markdown code.
 
 ```yaml
 DscResource.DocGenerator:

--- a/README.md
+++ b/README.md
@@ -246,8 +246,8 @@ possible to configure regular expressions to remove the markdown code.
 The regular expressions must be written so that capture group 0 returns 
 the full match and the capture group 1 returns the text that should be kept. 
 For example the regular expression `` \`(.+?)\` `` will find `` `$true` ``
-which will be replaced to `$true` since that is what will returned by capture
-group 1.
+which will be replaced to `$true` since that is what will be returned by
+capture group 1.
 
 Below is some example regular expression for the most comment markdown code.
 

--- a/source/tasks/Generate_Conceptual_Help.build.ps1
+++ b/source/tasks/Generate_Conceptual_Help.build.ps1
@@ -18,6 +18,14 @@
         The path to the source folder name. Defaults to the same path where the
         module manifest is found.
 
+    .PARAMETER MarkdownCodeRegularExpression
+        An array with regular expressions that will be used to remove markdown code
+        from the schema mof property descriptions. The regular expressions must be
+        written so that capture group 0 returns the full match and the capture group
+        1 returns the text that should be kept. For example the regular expression
+        \`(.+?)\` will find `$true` which will be replaced to $true since that is
+        what will be returned by capture group 1.
+
     .PARAMETER BuildInfo
         The build info object from ModuleBuilder. Defaults to an empty hashtable.
 
@@ -75,6 +83,10 @@ param
                 }).Directory.FullName
         )
     ),
+
+    [Parameter()]
+    [System.String]
+    $MarkdownCodeRegularExpression = (property MarkdownCodeRegularExpression @()),
 
     [Parameter()]
     [System.Collections.Hashtable]

--- a/source/tasks/Generate_Conceptual_Help.build.ps1
+++ b/source/tasks/Generate_Conceptual_Help.build.ps1
@@ -98,15 +98,38 @@ task Generate_Conceptual_Help {
 
     $builtModulePath = Join-Path -Path (Join-Path -Path $OutputDirectory -ChildPath $ProjectName) -ChildPath $ModuleVersionFolder
 
-    "`tProject Path            = $ProjectPath"
-    "`tProject Name            = $ProjectName"
-    "`tModule Version          = $moduleVersion"
-    "`tModule Version Folder   = $ModuleVersionFolder"
-    "`tPrerelease String       = $PreReleaseString"
-    "`tSource Path             = $SourcePath"
-    "`tBuilt Module Path       = $builtModulePath"
+    "`tProject Path                  = $ProjectPath"
+    "`tProject Name                  = $ProjectName"
+    "`tModule Version                = $moduleVersion"
+    "`tModule Version Folder         = $ModuleVersionFolder"
+    "`tPrerelease String             = $PreReleaseString"
+    "`tSource Path                   = $SourcePath"
+    "`tBuilt Module Path             = $builtModulePath"
+
+    $configParameterName = 'MarkdownCodeRegularExpression'
+
+    if (-not (Get-Variable -Name $configParameterName -ValueOnly -ErrorAction 'SilentlyContinue'))
+    {
+        # Variable is not set in context, try to use value from $BuildInfo.
+        $configParameterValue = $BuildInfo.'DscResource.DocGenerator'.Generate_Conceptual_Help.$configParameterName
+
+        <#
+            Always set the value. It will be set to $null if the parameter does
+            not exist in the variable $BuildInfo.
+
+            Always setting this variable is a workaround because the the parameter
+            MarkdownCodeRegularExpression's default value that uses 'property'
+            will wrongly return a collection of 1 where item 1 has a blank value.
+        #>
+        Set-Variable -Name $configParameterName -Value $configParameterValue
+    }
+
+    if ($MarkdownCodeRegularExpression)
+    {
+        "`tMarkdownCodeRegularExpression = RegEx: {0}" -f ($MarkdownCodeRegularExpression -join ' | RegEx: ')
+    }
 
     Write-Build Magenta "Generating conceptual help for all DSC resources based on source."
 
-    New-DscResourcePowerShellHelp -ModulePath $SourcePath -DestinationModulePath $builtModulePath
+    New-DscResourcePowerShellHelp -ModulePath $SourcePath -DestinationModulePath $builtModulePath -MarkdownCodeRegularExpression $MarkdownCodeRegularExpression
 }

--- a/tests/unit/tasks/Generate_Conceptual_Help.build.Tests.ps1
+++ b/tests/unit/tasks/Generate_Conceptual_Help.build.Tests.ps1
@@ -74,4 +74,35 @@ Describe 'Generate_Conceptual_Help' {
             } -Exactly -Times 1 -Scope It
         }
     }
+
+    Context 'When the generating conceptual help and parsing markdown code for a built module' {
+        BeforeAll {
+            # This mocks the alias 'property' for the parameter 'ModuleVersion'.
+            Mock -Command Get-BuiltModuleVersion -MockWith {
+                return '99.1.1-preview0001'
+            }
+
+            $mockTaskParameters = @{
+                ProjectName = 'MyModule'
+                SourcePath = $TestDrive
+                MarkdownCodeRegularExpression = @(
+                    '\`(.+?)\`'
+                )
+            }
+
+            $mockExpectedDestinationModulePath = Join-Path -Path $script:projectPath -ChildPath 'output' |
+                Join-Path -ChildPath $mockTaskParameters.ProjectName |
+                    Join-Path -ChildPath '99.1.1'
+        }
+
+        It 'Should run the build task with the correct destination module path and without throwing' {
+            {
+                Invoke-Build -Task $buildTaskName -File $script:buildScript.Definition @mockTaskParameters
+            } | Should -Not -Throw
+
+            Assert-MockCalled -CommandName New-DscResourcePowerShellHelp -ParameterFilter {
+                $DestinationModulePath -eq $mockExpectedDestinationModulePath
+            } -Exactly -Times 1 -Scope It
+        }
+    }
 }


### PR DESCRIPTION
# Pull Request

### Pull Request (PR) description
- The build task `Generate_Conceptual_Help` can now remove markdown code
  from the schema MOF parameter descriptions if markdown code is used to
  improve the Wiki documentation.

_Happy to rename parameters if there is a more suitable name._

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Documentation added/updated in README.md.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (where possible).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.docgenerator/40)
<!-- Reviewable:end -->
