### PR TITLE
New-DscResourcePowerShellHelp: Case-insensitive when it looks for the README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- New-DscResourcePowerShellHelp
+  - Fixed so the cmdlet is case-insensitive when it looks for the README.md
+    file in a resource source folder ([issue #42](https://github.com/dsccommunity/DscResource.DocGenerator/issues/42)).
+
 ## [0.7.0] - 2020-07-08
 
 ### Added
@@ -20,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update README.md with the correct build task name; 'Publish_GitHub_Wiki_Content'.
 - Fixed wiki generation to correctly describe embedded instances in
   parameters and made new section for each embedded instances with
-  their parameters ([issue #37](https://github.com/dsccommunity/DscResource.DocGenerator/issues/37))
+  their parameters ([issue #37](https://github.com/dsccommunity/DscResource.DocGenerator/issues/37)).
 
 ### Changed
 

--- a/source/Public/New-DscResourcePowerShellHelp.ps1
+++ b/source/Public/New-DscResourcePowerShellHelp.ps1
@@ -97,9 +97,13 @@ function New-DscResourcePowerShellHelp
                 -and ($null -ne $_.FriendlyName)
         }
 
-        $descriptionPath = Join-Path -Path $mofSchema.DirectoryName -ChildPath 'readme.md'
+        # This is a workaround for issue #42.
+        $descriptionPath = Get-ChildItem -Path $mofSchema.DirectoryName -ErrorAction 'SilentlyContinue' |
+            Where-Object -FilterScript {
+                $_.Name -like 'readme.md'
+            }
 
-        if (Test-Path -Path $descriptionPath)
+        if ($descriptionPath)
         {
             Write-Verbose -Message ($script:localizedData.GenerateHelpDocumentMessage -f $result.FriendlyName)
 

--- a/source/Public/New-DscResourcePowerShellHelp.ps1
+++ b/source/Public/New-DscResourcePowerShellHelp.ps1
@@ -98,13 +98,15 @@ function New-DscResourcePowerShellHelp
         }
 
         # This is a workaround for issue #42.
-        $descriptionPath = Get-ChildItem -Path $mofSchema.DirectoryName -ErrorAction 'SilentlyContinue' |
+        $readMeFile = Get-ChildItem -Path $mofSchema.DirectoryName -ErrorAction 'SilentlyContinue' |
             Where-Object -FilterScript {
                 $_.Name -like 'readme.md'
             }
 
-        if ($descriptionPath)
+        if ($readMeFile)
         {
+            $descriptionPath = $readMeFile.FullName
+
             Write-Verbose -Message ($script:localizedData.GenerateHelpDocumentMessage -f $result.FriendlyName)
 
             $output = ".NAME`r`n"

--- a/tests/unit/public/New-DscResourcePowerShellHelp.Tests.ps1
+++ b/tests/unit/public/New-DscResourcePowerShellHelp.Tests.ps1
@@ -360,6 +360,7 @@ Configuration Example
                     -ParameterFilter $script:getChildItemReadme_parameterFilter `
                     -MockWith {
                         return [PSCustomObject] @{
+                            # This is intentionally using the upper-case 'README.md'.
                             Name = 'README.md'
                             FullName = Join-Path -Path $script:mockReadmePath -ChildPath 'README.md'
                         }
@@ -450,6 +451,7 @@ Configuration Example
                     -ParameterFilter $script:getChildItemReadme_parameterFilter `
                     -MockWith {
                         return [PSCustomObject] @{
+                            # This is intentionally using the upper-case 'README.md'.
                             Name = 'README.md'
                             FullName = Join-Path -Path $script:mockReadmePath -ChildPath 'README.md'
                         }
@@ -553,6 +555,7 @@ Configuration Example
                     -ParameterFilter $script:getChildItemReadme_parameterFilter `
                     -MockWith {
                         return [PSCustomObject] @{
+                            # This is intentionally using the upper-case 'README.md'.
                             Name = 'README.md'
                             FullName = Join-Path -Path $script:mockReadmePath -ChildPath 'README.md'
                         }
@@ -656,8 +659,9 @@ Configuration Example
                     -ParameterFilter $script:getChildItemReadme_parameterFilter `
                     -MockWith {
                         return [PSCustomObject] @{
-                            Name = 'README.md'
-                            FullName = Join-Path -Path $script:mockReadmePath -ChildPath 'README.md'
+                            # This is intentionally using the lower-case 'readme.md'.
+                            Name = 'readme.md'
+                            FullName = Join-Path -Path $script:mockReadmePath -ChildPath 'readme.md'
                         }
                      }
 

--- a/tests/unit/public/New-DscResourcePowerShellHelp.Tests.ps1
+++ b/tests/unit/public/New-DscResourcePowerShellHelp.Tests.ps1
@@ -146,7 +146,7 @@ Configuration Example
 }'
 
         # General mock values
-        $script:mockReadmePath = Join-Path -Path $script:mockSchemaFolder -ChildPath 'readme.md'
+        $script:mockReadmePath = $script:mockSchemaFolder
         $script:mockOutputFile = Join-Path -Path $script:mockOutputPath -ChildPath "$($script:mockResourceName).md"
         $script:mockSavePath = Join-Path -Path $script:mockModulePath -ChildPath "DscResources\$($script:mockResourceName)\en-US\about_$($script:mockResourceName).help.txt"
         $script:mockOutputSavePath = Join-Path -Path $script:mockOutputPath -ChildPath "about_$($script:mockResourceName).help.txt"
@@ -212,12 +212,12 @@ Configuration Example
             $Filename -eq $script:mockSchemaFilePath
         }
 
-        $script:getTestPathReadme_parameterFilter = {
+        $script:getChildItemReadme_parameterFilter = {
             $Path -eq $script:mockReadmePath
         }
 
         $script:getContentReadme_parameterFilter = {
-            $Path -eq $script:mockReadmePath
+            $Path -eq (Join-Path -Path $script:mockReadmePath -ChildPath 'README.md')
         }
 
         $script:getDscResourceHelpExampleContent_parameterFilter = {
@@ -309,9 +309,8 @@ Configuration Example
                     -MockWith { $script:mockGetMofSchemaObject }
 
                 Mock `
-                    -CommandName Test-Path `
-                    -ParameterFilter $script:getTestPathReadme_parameterFilter `
-                    -MockWith { $false }
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $script:getChildItemReadme_parameterFilter `
 
                 Mock `
                     -CommandName Out-File `
@@ -357,9 +356,14 @@ Configuration Example
                     -MockWith { $script:mockGetMofSchemaObject }
 
                 Mock `
-                    -CommandName Test-Path `
-                    -ParameterFilter $script:getTestPathReadme_parameterFilter `
-                    -MockWith { $true }
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $script:getChildItemReadme_parameterFilter `
+                    -MockWith {
+                        return [PSCustomObject] @{
+                            Name = 'README.md'
+                            FullName = Join-Path -Path $script:mockReadmePath -ChildPath 'README.md'
+                        }
+                     }
 
                 Mock `
                     -CommandName Get-Content `

--- a/tests/unit/public/New-DscResourcePowerShellHelp.Tests.ps1
+++ b/tests/unit/public/New-DscResourcePowerShellHelp.Tests.ps1
@@ -310,7 +310,7 @@ Configuration Example
 
                 Mock `
                     -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemReadme_parameterFilter `
+                    -ParameterFilter $script:getChildItemReadme_parameterFilter
 
                 Mock `
                     -CommandName Out-File `
@@ -397,6 +397,11 @@ Configuration Example
                     -Exactly -Times 1
 
                 Assert-MockCalled `
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $script:getChildItemReadme_parameterFilter `
+                    -Exactly -Times 1
+
+                Assert-MockCalled `
                     -CommandName Get-Content `
                     -ParameterFilter $script:getContentReadme_parameterFilter `
                     -Exactly -Times 1
@@ -441,9 +446,14 @@ Configuration Example
                     -MockWith { $script:mockGetMofSchemaObject }
 
                 Mock `
-                    -CommandName Test-Path `
-                    -ParameterFilter $script:getTestPathReadme_parameterFilter `
-                    -MockWith { $true }
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $script:getChildItemReadme_parameterFilter `
+                    -MockWith {
+                        return [PSCustomObject] @{
+                            Name = 'README.md'
+                            FullName = Join-Path -Path $script:mockReadmePath -ChildPath 'README.md'
+                        }
+                     }
 
                 Mock `
                     -CommandName Get-Content `
@@ -495,8 +505,8 @@ Configuration Example
                     -Exactly -Times 1
 
                 Assert-MockCalled `
-                    -CommandName Test-Path `
-                    -ParameterFilter $script:getTestPathReadme_parameterFilter `
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $script:getChildItemReadme_parameterFilter `
                     -Exactly -Times 1
 
                 Assert-MockCalled `
@@ -539,9 +549,14 @@ Configuration Example
                     -MockWith { $script:mockGetMofSchemaObject }
 
                 Mock `
-                    -CommandName Test-Path `
-                    -ParameterFilter $script:getTestPathReadme_parameterFilter `
-                    -MockWith { $true }
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $script:getChildItemReadme_parameterFilter `
+                    -MockWith {
+                        return [PSCustomObject] @{
+                            Name = 'README.md'
+                            FullName = Join-Path -Path $script:mockReadmePath -ChildPath 'README.md'
+                        }
+                     }
 
                 Mock `
                     -CommandName Get-Content `
@@ -593,8 +608,8 @@ Configuration Example
                     -Exactly -Times 1
 
                 Assert-MockCalled `
-                    -CommandName Test-Path `
-                    -ParameterFilter $script:getTestPathReadme_parameterFilter `
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $script:getChildItemReadme_parameterFilter `
                     -Exactly -Times 1
 
                 Assert-MockCalled `
@@ -637,9 +652,14 @@ Configuration Example
                     -MockWith { $script:mockGetMofSchemaObject }
 
                 Mock `
-                    -CommandName Test-Path `
-                    -ParameterFilter $script:getTestPathReadme_parameterFilter `
-                    -MockWith { $true }
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $script:getChildItemReadme_parameterFilter `
+                    -MockWith {
+                        return [PSCustomObject] @{
+                            Name = 'README.md'
+                            FullName = Join-Path -Path $script:mockReadmePath -ChildPath 'README.md'
+                        }
+                     }
 
                 Mock `
                     -CommandName Get-Content `
@@ -691,8 +711,8 @@ Configuration Example
                     -Exactly -Times 1
 
                 Assert-MockCalled `
-                    -CommandName Test-Path `
-                    -ParameterFilter $script:getTestPathReadme_parameterFilter `
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $script:getChildItemReadme_parameterFilter `
                     -Exactly -Times 1
 
                 Assert-MockCalled `
@@ -778,9 +798,14 @@ Configuration Example
                     -MockWith { $script:mockGetMofSchemaObject }
 
                 Mock `
-                    -CommandName Test-Path `
-                    -ParameterFilter $script:getTestPathReadme_parameterFilter `
-                    -MockWith { $true }
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $script:getChildItemReadme_parameterFilter `
+                    -MockWith {
+                        return [PSCustomObject] @{
+                            Name = 'README.md'
+                            FullName = Join-Path -Path $script:mockReadmePath -ChildPath 'README.md'
+                        }
+                     }
 
                 Mock `
                     -CommandName Get-Content `
@@ -837,8 +862,8 @@ Configuration Example
                     -Exactly -Times 1
 
                 Assert-MockCalled `
-                    -CommandName Test-Path `
-                    -ParameterFilter $script:getTestPathReadme_parameterFilter `
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $script:getChildItemReadme_parameterFilter `
                     -Exactly -Times 1
 
                 Assert-MockCalled `


### PR DESCRIPTION


# Pull Request

### Pull Request (PR) description
- New-DscResourcePowerShellHelp
  - Fixed so the cmdlet is case-insensitive when it looks for the README.md
    file in a resource source folder (issue #42).

#### This Pull Request (PR) fixes the following issues

- Fixes #42


#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [ ] Integration tests added/updated (where possible).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.docgenerator/43)
<!-- Reviewable:end -->
