### PR TITLE
BREAKING CHANGE: Add wiki generation support for class-based resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a new private function `Get-ClassResourceCommentBasedHelp` to get
+  comment-based help from a PowerShell script file.
+
 ### Changed
 
 - `Split-ModuleVersion`
   - This cmdlet is not exported as a public function because it is required
     by the build task `Generate_Wiki_Content`.
-    
+
 ## [0.7.4] - 2021-02-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Split-ModuleVersion`
   - This cmdlet is now exported as a public function because it is required
     by the build task `Generate_Wiki_Content`.
+- `Generate_Wiki_Content`
+  - The Build task `Generate_Wiki_Content` was changed to call the cmdlet
+    `New-DscResourceWikiPage` with the correct parameters to support generating
+    documentation for class-based resource ([issue #52](https://github.com/dsccommunity/DscResource.DocGenerator/issues/52)).
 
 ## [0.7.4] - 2021-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a new private function `Get-ClassResourceCommentBasedHelp` to get
   comment-based help from a PowerShell script file.
+- Added a new private function `Get-ClassResourcePropertyState` to get
+  named attribute argument (from the attribute `[DscProperty()]`) for a
+  class-based resource parameter and return the corresponding name used by
+  MOF-based resources.
 - Added a test helper module `DscResource.DocGenerator.TestHelper.psm1`
   that contain helper functions for tests.
   - Added helper function `Out-Diff` that outputs two text strings in hex
@@ -17,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `Split-ModuleVersion`
-  - This cmdlet is not exported as a public function because it is required
+  - This cmdlet is now exported as a public function because it is required
     by the build task `Generate_Wiki_Content`.
 
 ## [0.7.4] - 2021-02-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     ([issue #52](https://github.com/dsccommunity/DscResource.DocGenerator/issues/52)).
   - **BREAKING CHANGE:** To support class-based resource the parameters were
     renamed to better recognize what path goes where.
+  - Each values that are in a `ValueMap` of a MOF schema parameter, or in
+    a `ValidateSet()` of a class-based resource parameter, will be outputted
+    as markdown inline code.
 
 ## [0.7.4] - 2021-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `Split-ModuleVersion`
+  - This cmdlet is not exported as a public function because it is required
+    by the build task `Generate_Wiki_Content`.
+    
 ## [0.7.4] - 2021-02-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a new private function `Get-ClassResourceCommentBasedHelp` to get
   comment-based help from a PowerShell script file.
+- Added a test helper module `DscResource.DocGenerator.TestHelper.psm1`
+  that contain helper functions for tests.
+  - Added helper function `Out-Diff` that outputs two text strings in hex
+    side-by-side (thanks to @johanringman for help with this one).
 
 ### Changed
 
@@ -22,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Get-ResourceExampleAsText`
   - Comment-based help was updated to reflect the correct parameters.
+- `New-DscResourcePowerShellHelp`
+  - Fixed unit tests to support new private function `Get-ClassResourceCommentBasedHelp`
+    and use the test helper module `DscResource.DocGenerator.TestHelper.psm1`.
+  - It no longer uses `Recurse` when looking for the module's PowerShell
+    script files. It could potentially lead to that it found resources that
+    are part of common modules in the `Modules` folder.
+  - Made use of private functions to reduce duplicate code.
 
 ## [0.7.4] - 2021-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a test helper module `DscResource.DocGenerator.TestHelper.psm1`
   that contain helper functions for tests.
   - Added helper function `Out-Diff` that outputs two text strings in hex
-    side-by-side (thanks to @johanringman for help with this one).
+    side-by-side (thanks to [@johanringman](https://github.com/johanringman)
+    for help with this one).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     a `ValidateSet()` of a class-based resource parameter, will be outputted
     as markdown inline code.
 
-## [0.7.4] - 2021-02-02
-
 ### Fixed
 
 - `Get-ResourceExampleAsText`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   named attribute argument (from the attribute `[DscProperty()]`) for a
   class-based resource parameter and return the corresponding name used by
   MOF-based resources.
+- Added a new private function `Get-ResourceExampleAsMarkdown` that helps
+  to return examples as markdown, and to reduce code duplication.
 - Added a test helper module `DscResource.DocGenerator.TestHelper.psm1`
   that contain helper functions for tests.
   - Added helper function `Out-Diff` that outputs two text strings in hex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Get-ResourceExampleAsText`
+  - Comment-based help was updated to reflect the correct parameters.
+
+## [0.7.4] - 2021-02-02
+
+### Fixed
+
 - Conceptual help for MOF-based resource works again (broken in v0.7.3)
   ([issue #55](https://github.com/dsccommunity/DscResource.DocGenerator/issues/55)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The Build task `Generate_Wiki_Content` was changed to call the cmdlet
     `New-DscResourceWikiPage` with the correct parameters to support generating
     documentation for class-based resource ([issue #52](https://github.com/dsccommunity/DscResource.DocGenerator/issues/52)).
+- `New-DscResourceWikiPage`
+  - Now supports generating wiki documentation for class-based resources
+    ([issue #52](https://github.com/dsccommunity/DscResource.DocGenerator/issues/52)).
+  - **BREAKING CHANGE:** To support class-based resource the parameters were
+    renamed to better recognize what path goes where.
 
 ## [0.7.4] - 2021-02-02
 
@@ -43,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     script files. It could potentially lead to that it found resources that
     are part of common modules in the `Modules` folder.
   - Made use of private functions to reduce duplicate code.
+- `Get-DscResourceSchemaPropertyContent`
+  - Fixed the private function so that the description property no longer
+    output an extra whitespace in some circumstances.
 
 ## [0.7.4] - 2021-02-02
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,38 @@ Set-WikiModuleVersion -Path '.\output\WikiContent\Home.md' -ModuleVersion '14.0.
 
 Replaces '#.#.#' with the module version '14.0.0' in the markdown file 'Home.md'.
 
+### `Split-ModuleVersion`
+
+This function parses a module version string as returns a hashtable
+which each of the module version's parts.
+
+#### Syntax
+
+<!-- markdownlint-disable MD013 - Line length -->
+```plaintext
+Split-ModuleVersion [[-ModuleVersion] <string>] [<CommonParameters>]
+```
+<!-- markdownlint-enable MD013 - Line length -->
+
+#### Outputs
+
+System.Management.Automation.PSCustomObject
+
+#### Example
+
+```powershell
+Split-ModuleVersion -ModuleVersion '1.15.0-pr0224-0022+Sha.47ae45eb'
+```
+
+Splits the module version an returns a PSCustomObject with the parts
+of the module version.
+
+```plaintext
+Version PreReleaseString ModuleVersion
+------- ---------------- -------------
+1.15.0  pr0224           1.15.0-pr0224
+```
+
 ## Tasks
 
 These are `Invoke-Build` tasks. The build tasks are primarily meant to be

--- a/source/Private/Get-ClassResourceCommentBasedHelp.ps1
+++ b/source/Private/Get-ClassResourceCommentBasedHelp.ps1
@@ -1,0 +1,59 @@
+<#
+    .SYNOPSIS
+        Get-ClassResourceCommentBasedHelp returns comment-based help for a DSC resource.
+
+    .DESCRIPTION
+        Get-ClassResourceCommentBasedHelp returns comment-based help for a DSC resource
+        by parsing the source PowerShell script file.
+
+    .PARAMETER Path
+        The path to the DSC resource PowerShell script file. This should be a
+        PowerShell script file that only contain one resource with the
+        comment-based help at the top of the file.
+
+    .OUTPUTS
+        System.Management.Automation.Language.CommentHelpInfo
+
+    .EXAMPLE
+        $commentBasedHelp = Get-ClassResourceCommentBasedHelp -Path 'c:\MyProject\source\Classes\010-MyResourceName.ps1'
+
+        This example parses the comment-based help from the PowerShell script file
+        'c:\MyProject\source\Classes\010-MyResourceName.ps1' and returns an
+        object of System.Management.Automation.Language.CommentHelpInfo.
+#>
+function Get-ClassResourceCommentBasedHelp
+{
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.Language.CommentHelpInfo])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Path
+    )
+
+    <#
+        PowerShell classes does not support comment-based help. There is
+        no GetHelpContent() on the TypeDefinitionAst.
+
+        We use the ScriptBlockAst to filter out our class-based resource
+        script block from the source file and use that to get the
+        comment-based help.
+    #>
+    $Path = Resolve-Path -Path $Path
+
+    Write-Verbose -Message ($script:localizedData.ClassBasedCommentBasedHelpMessage -f $Path)
+
+    $tokens, $parseErrors = $null
+
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref] $tokens, [ref] $parseErrors)
+
+    if ($parseErrors)
+    {
+        throw $parseErrors
+    }
+
+    $dscResourceCommentBasedHelp = $ast.GetHelpContent()
+
+    return $dscResourceCommentBasedHelp
+}

--- a/source/Private/Get-ClassResourceCommentBasedHelp.ps1
+++ b/source/Private/Get-ClassResourceCommentBasedHelp.ps1
@@ -50,7 +50,18 @@ function Get-ClassResourceCommentBasedHelp
 
     if ($parseErrors)
     {
-        throw $parseErrors
+        <#
+            Normally we should throw if there is any parse errors but in the case
+            of the class-based resource source file that is not possible. If the
+            class is inheriting from a base class that base class is not part of
+            the source script file which will generate a parse error.
+            Even with parse errors the comment-based help is available with
+            GetHelpContent(). The errors are outputted for debug purposes, if there
+            would be a future problem that we have not taken account for.
+        #>
+        Write-Debug -Message (
+            $script:localizedData.IgnoreAstParseErrorMessage -f ($parseErrors | Out-String)
+        )
     }
 
     $dscResourceCommentBasedHelp = $ast.GetHelpContent()

--- a/source/Private/Get-ClassResourcePropertyState.ps1
+++ b/source/Private/Get-ClassResourcePropertyState.ps1
@@ -1,0 +1,39 @@
+function Get-ClassResourcePropertyState
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.Management.Automation.Language.PropertyMemberAst]
+        $Ast
+    )
+
+    $astFilter = {
+        $args[0] -is [System.Management.Automation.Language.NamedAttributeArgumentAst]
+    }
+
+    $propertyNamedAttributeArgumentAsts = $Ast.FindAll($astFilter, $true)
+
+    $isKeyProperty = 'Key' -in $propertyNamedAttributeArgumentAsts.ArgumentName
+    $isMandatoryProperty = 'Mandatory' -in $propertyNamedAttributeArgumentAsts.ArgumentName
+    $isReadProperty = 'NotConfigurable' -in $propertyNamedAttributeArgumentAsts.ArgumentName
+
+    if ($isKeyProperty)
+    {
+        $propertyState = 'Key'
+    }
+    elseif ($isMandatoryProperty)
+    {
+        $propertyState = 'Required'
+    }
+    elseif ($isReadProperty)
+    {
+        $propertyState = 'Read'
+    }
+    else
+    {
+        $propertyState = 'Write'
+    }
+
+    return $propertyState
+}

--- a/source/Private/Get-ClassResourcePropertyState.ps1
+++ b/source/Private/Get-ClassResourcePropertyState.ps1
@@ -1,36 +1,65 @@
+<#
+    .SYNOPSIS
+        This function returns the property state value of an class-based DSC
+        resource property.
+
+    .DESCRIPTION
+        This function returns the property state value of an DSC class-based
+        resource property.
+
+    .PARAMETER Ast
+        The AST for class-based DSC resource property. The passed value must
+        be an AST of the type 'PropertyMemberAst'.
+
+    .EXAMPLE
+        Get-ClassResourcePropertyState -Ast {
+            [DscResource()]
+            class NameOfResource {
+                [DscProperty(Key)]
+                [string] $KeyName
+
+                [NameOfResource] Get() {
+                    return $this
+                }
+
+                [void] Set() {}
+
+                [bool] Test() {
+                    return $true
+                }
+            }
+        }.Ast.Find({$args[0] -is [System.Management.Automation.Language.PropertyMemberAst]}, $false)
+
+        Returns the property state for the property 'KeyName'.
+#>
 function Get-ClassResourcePropertyState
 {
     [CmdletBinding()]
+    [OutputType([System.String])]
     param
     (
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.Management.Automation.Language.PropertyMemberAst]
         $Ast
     )
 
-    $astFilter = {
-        $args[0] -is [System.Management.Automation.Language.NamedAttributeArgumentAst]
-    }
-
-    $propertyNamedAttributeArgumentAsts = $Ast.FindAll($astFilter, $true)
-
-    $isKeyProperty = 'Key' -in $propertyNamedAttributeArgumentAsts.ArgumentName
-    $isMandatoryProperty = 'Mandatory' -in $propertyNamedAttributeArgumentAsts.ArgumentName
-    $isReadProperty = 'NotConfigurable' -in $propertyNamedAttributeArgumentAsts.ArgumentName
-
-    if ($isKeyProperty)
+    <#
+        Check for Key first since it it possible to use both Key and Mandatory
+        on a property and in that case we want to return just 'Key'.
+    #>
+    if ((Test-PropertyMemberAst -IsKey -Ast $Ast))
     {
         $propertyState = 'Key'
     }
-    elseif ($isMandatoryProperty)
+    elseif ((Test-PropertyMemberAst -IsMandatory -Ast $Ast))
     {
         $propertyState = 'Required'
     }
-    elseif ($isReadProperty)
+    elseif ((Test-PropertyMemberAst -IsRead -Ast $Ast))
     {
         $propertyState = 'Read'
     }
-    else
+    elseif ((Test-PropertyMemberAst -IsWrite -Ast $Ast))
     {
         $propertyState = 'Write'
     }

--- a/source/Private/Get-ClassResourcePropertyState.ps1
+++ b/source/Private/Get-ClassResourcePropertyState.ps1
@@ -8,8 +8,8 @@
         resource property.
 
     .PARAMETER Ast
-        The AST for class-based DSC resource property. The passed value must
-        be an AST of the type 'PropertyMemberAst'.
+        The Abstract Syntax Tree (AST) for class-based DSC resource property.
+        The passed value must be an AST of the type 'PropertyMemberAst'.
 
     .EXAMPLE
         Get-ClassResourcePropertyState -Ast {

--- a/source/Private/Get-DscResourceSchemaPropertyContent.ps1
+++ b/source/Private/Get-DscResourceSchemaPropertyContent.ps1
@@ -34,7 +34,11 @@ function Get-DscResourceSchemaPropertyContent
     (
         [Parameter(Mandatory = $true)]
         [System.Collections.Hashtable[]]
-        $Property
+        $Property,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UseMarkdown
     )
 
     $stringArray = [System.String[]] @()
@@ -76,7 +80,16 @@ function Get-DscResourceSchemaPropertyContent
 
         if (-not [System.String]::IsNullOrEmpty($currentProperty.ValueMap))
         {
-            $propertyLine += ' ' + ($currentProperty.ValueMap -join ', ')
+            $valueMap = $currentProperty.ValueMap
+
+            if ($UseMarkdown.IsPresent)
+            {
+                $valueMap = $valueMap | ForEach-Object -Process {
+                    '`{0}`' -f $_
+                }
+            }
+
+            $propertyLine += ' ' + ($valueMap -join ', ')
         }
 
         $propertyLine += ' |'

--- a/source/Private/Get-DscResourceSchemaPropertyContent.ps1
+++ b/source/Private/Get-DscResourceSchemaPropertyContent.ps1
@@ -65,8 +65,14 @@ function Get-DscResourceSchemaPropertyContent
 
         $propertyLine = "| **$($currentProperty.Name)** " + `
                 "| $($currentProperty.State) " + `
-                "| $dataType " + `
-                "| $($currentProperty.Description) |"
+                "| $dataType |"
+
+        if (-not [System.String]::IsNullOrEmpty($currentProperty.Description))
+        {
+            $propertyLine += ' ' + $currentProperty.Description
+        }
+
+        $propertyLine += ' |'
 
         if (-not [System.String]::IsNullOrEmpty($currentProperty.ValueMap))
         {

--- a/source/Private/Get-ResourceExampleAsMarkdown.ps1
+++ b/source/Private/Get-ResourceExampleAsMarkdown.ps1
@@ -8,7 +8,9 @@
         them as string build object in markdown format.
 
     .PARAMETER Path
-        The path to the source folder where the examples for the resource exist.
+        The path to the source folder, the path will be recursively searched for *.ps1
+        files. All found files will be assumed that they are examples and that
+        documentation should be generated for them.
 
     .EXAMPLE
         $examplesMarkdown = Get-ResourceExampleAsMarkdown -Path 'c:\MyProject\source\Examples\Resources\MyResourceName'

--- a/source/Private/Get-ResourceExampleAsMarkdown.ps1
+++ b/source/Private/Get-ResourceExampleAsMarkdown.ps1
@@ -1,0 +1,60 @@
+<#
+    .SYNOPSIS
+        Get-ResourceExampleAsMarkdown gathers all examples for a resource and returns
+        them as string build object in markdown format.
+
+    .DESCRIPTION
+        Get-ResourceExampleAsMarkdown gathers all examples for a resource and returns
+        them as string build object in markdown format.
+
+    .PARAMETER Path
+        The path to the source folder where the examples for the resource exist.
+
+    .EXAMPLE
+        $examplesMarkdown = Get-ResourceExampleAsMarkdown -Path 'c:\MyProject\source\Examples\Resources\MyResourceName'
+
+        This example fetches all examples from the folder 'c:\MyProject\source\Examples\Resources\MyResourceName'
+        and returns them as a single string in markdown format.
+#>
+function Get-ResourceExampleAsMarkdown
+{
+    [CmdletBinding()]
+    [OutputType([System.Text.StringBuilder])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Path
+    )
+
+    $filePath = Join-Path -Path $Path -ChildPath '*.ps1'
+
+    $exampleFiles = @(Get-ChildItem -Path $filePath -File -Recurse -ErrorAction 'SilentlyContinue')
+
+    if ($exampleFiles.Count -gt 0)
+    {
+        $output = New-Object -TypeName 'System.Text.StringBuilder'
+
+        Write-Verbose -Message ($script:localizedData.FoundResourceExamplesMessage -f $exampleFiles.Count)
+
+        $null = $output.AppendLine('## Examples')
+
+        $exampleCount = 1
+
+        foreach ($exampleFile in $exampleFiles)
+        {
+            $exampleContent = Get-DscResourceWikiExampleContent `
+                -ExamplePath $exampleFile.FullName `
+                -ExampleNumber ($exampleCount++)
+
+            $null = $output.AppendLine()
+            $null = $output.AppendLine($exampleContent)
+        }
+    }
+    else
+    {
+        Write-Warning -Message ($script:localizedData.NoExampleFileFoundWarning)
+    }
+
+    return $output
+}

--- a/source/Private/Get-ResourceExampleAsMarkdown.ps1
+++ b/source/Private/Get-ResourceExampleAsMarkdown.ps1
@@ -33,11 +33,11 @@ function Get-ResourceExampleAsMarkdown
 
     if ($exampleFiles.Count -gt 0)
     {
-        $output = New-Object -TypeName 'System.Text.StringBuilder'
+        $outputExampleMarkDown = New-Object -TypeName 'System.Text.StringBuilder'
 
         Write-Verbose -Message ($script:localizedData.FoundResourceExamplesMessage -f $exampleFiles.Count)
 
-        $null = $output.AppendLine('## Examples')
+        $null = $outputExampleMarkDown.AppendLine('## Examples')
 
         $exampleCount = 1
 
@@ -47,8 +47,8 @@ function Get-ResourceExampleAsMarkdown
                 -ExamplePath $exampleFile.FullName `
                 -ExampleNumber ($exampleCount++)
 
-            $null = $output.AppendLine()
-            $null = $output.AppendLine($exampleContent)
+            $null = $outputExampleMarkDown.AppendLine()
+            $null = $outputExampleMarkDown.AppendLine($exampleContent)
         }
     }
     else
@@ -56,5 +56,5 @@ function Get-ResourceExampleAsMarkdown
         Write-Warning -Message ($script:localizedData.NoExampleFileFoundWarning)
     }
 
-    return $output
+    return $outputExampleMarkDown
 }

--- a/source/Private/Get-ResourceExampleAsText.ps1
+++ b/source/Private/Get-ResourceExampleAsText.ps1
@@ -8,7 +8,9 @@
         them as a string in a format that is used for conceptual help.
 
     .PARAMETER Path
-        The path to the source folder where the examples for the resource exist.
+        The path to the source folder, the path will be recursively searched for *.ps1
+        files. All found files will be assumed that they are examples and that
+        documentation should be generated for them.
 
     .EXAMPLE
         $examplesText = Get-ResourceExampleAsText -Path 'c:\MyProject\source\Examples\Resources\MyResourceName'

--- a/source/Private/Get-ResourceExampleAsText.ps1
+++ b/source/Private/Get-ResourceExampleAsText.ps1
@@ -13,7 +13,7 @@
     .EXAMPLE
         $examplesText = Get-ResourceExampleAsText -Path 'c:\MyProject\source\Examples\Resources\MyResourceName'
 
-        This example fetches all examples from the folder 'ec:\MyProject\source\Examples\Resources\MyResourceName'
+        This example fetches all examples from the folder 'c:\MyProject\source\Examples\Resources\MyResourceName'
         and returns them as a single string in a format that is used for conceptual help.
 #>
 function Get-ResourceExampleAsText

--- a/source/Private/Get-ResourceExampleAsText.ps1
+++ b/source/Private/Get-ResourceExampleAsText.ps1
@@ -7,16 +7,13 @@
         Get-ResourceExampleAsText gathers all examples for a resource and returns
         them as a string in a format that is used for conceptual help.
 
-    .PARAMETER ResourceName
-        The name of the resource for which examples should be retrieved.
-
     .PARAMETER Path
-        THe path to the source folder where the folder Examples exist.
+        The path to the source folder where the examples for the resource exist.
 
     .EXAMPLE
-        $examplesText = Get-ResourceExampleAsText -ResourceName 'MyClassResource' -Path 'c:\MyProject'
+        $examplesText = Get-ResourceExampleAsText -Path 'c:\MyProject\source\Examples\Resources\MyResourceName'
 
-        This example fetches all examples from the folder 'c:\MyProject\Examples\Resources\MyClassResource'
+        This example fetches all examples from the folder 'ec:\MyProject\source\Examples\Resources\MyResourceName'
         and returns them as a single string in a format that is used for conceptual help.
 #>
 function Get-ResourceExampleAsText

--- a/source/Private/Test-PropertyMemberAst.ps1
+++ b/source/Private/Test-PropertyMemberAst.ps1
@@ -42,19 +42,19 @@ function Test-PropertyMemberAst
         [System.Management.Automation.Language.PropertyMemberAst]
         $Ast,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true, ParameterSetName='IsKey')]
         [System.Management.Automation.SwitchParameter]
         $IsKey,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true, ParameterSetName='IsMandatory')]
         [System.Management.Automation.SwitchParameter]
         $IsMandatory,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true, ParameterSetName='IsWrite')]
         [System.Management.Automation.SwitchParameter]
         $IsWrite,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true, ParameterSetName='IsRead')]
         [System.Management.Automation.SwitchParameter]
         $IsRead
     )

--- a/source/Private/Test-PropertyMemberAst.ps1
+++ b/source/Private/Test-PropertyMemberAst.ps1
@@ -1,0 +1,90 @@
+<#
+    .SYNOPSIS
+        This function returns the property state value of an class-based DSC
+        resource property.
+
+    .DESCRIPTION
+        This function returns the property state value of an DSC class-based
+        resource property.
+
+    .PARAMETER Ast
+        The AST for class-based DSC resource property. The passed value must
+        be an AST of the type 'PropertyMemberAst'.
+
+    .EXAMPLE
+        Test-PropertyMemberAst -IsKey -Ast {
+            [DscResource()]
+            class NameOfResource {
+                [DscProperty(Key)]
+                [string] $KeyName
+
+                [NameOfResource] Get() {
+                    return $this
+                }
+
+                [void] Set() {}
+
+                [bool] Test() {
+                    return $true
+                }
+            }
+        }.Ast.Find({$args[0] -is [System.Management.Automation.Language.PropertyMemberAst]}, $false)
+
+        Returns $true that the property 'KeyName' is Key.
+#>
+function Test-PropertyMemberAst
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.PropertyMemberAst]
+        $Ast,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $IsKey,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $IsMandatory,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $IsWrite,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $IsRead
+    )
+
+    $astFilter = {
+        $args[0] -is [System.Management.Automation.Language.NamedAttributeArgumentAst]
+    }
+
+    $propertyNamedAttributeArgumentAsts = $Ast.FindAll($astFilter, $true)
+
+    if ($IsKey.IsPresent -and 'Key' -in $propertyNamedAttributeArgumentAsts.ArgumentName)
+    {
+        return $true
+    }
+
+    # Having Key on a property makes it implicitly Mandatory.
+    if ($IsMandatory.IsPresent -and $propertyNamedAttributeArgumentAsts.ArgumentName -in @('Mandatory', 'Key'))
+    {
+        return $true
+    }
+
+    if ($IsRead.IsPresent -and 'NotConfigurable' -in $propertyNamedAttributeArgumentAsts.ArgumentName)
+    {
+        return $true
+    }
+
+    if ($IsWrite.IsPresent -and $propertyNamedAttributeArgumentAsts.ArgumentName -notin @('Key', 'Mandatory', 'NotConfigurable'))
+    {
+        return $true
+    }
+
+    return $false
+}

--- a/source/Private/Test-PropertyMemberAst.ps1
+++ b/source/Private/Test-PropertyMemberAst.ps1
@@ -8,8 +8,8 @@
         resource property.
 
     .PARAMETER Ast
-        The AST for class-based DSC resource property. The passed value must
-        be an AST of the type 'PropertyMemberAst'.
+        The Abstract Syntax Tree (AST) for class-based DSC resource property.
+        The passed value must be an AST of the type 'PropertyMemberAst'.
 
     .EXAMPLE
         Test-PropertyMemberAst -IsKey -Ast {

--- a/source/Public/New-DscResourceWikiPage.ps1
+++ b/source/Public/New-DscResourceWikiPage.ps1
@@ -89,7 +89,7 @@ function New-DscResourceWikiPage
             $null = $output.AppendLine('## Parameters')
             $null = $output.AppendLine('')
 
-            $propertyContent = Get-DscResourceSchemaPropertyContent -Property $resourceSchema.Attributes
+            $propertyContent = Get-DscResourceSchemaPropertyContent -Property $resourceSchema.Attributes -UseMarkdown
 
             foreach ($line in $propertyContent)
             {
@@ -113,7 +113,7 @@ function New-DscResourceWikiPage
                 $null = $output.AppendLine('#### Parameters')
                 $null = $output.AppendLine('')
 
-                $propertyContent = Get-DscResourceSchemaPropertyContent -Property $embeddedSchema.Attributes
+                $propertyContent = Get-DscResourceSchemaPropertyContent -Property $embeddedSchema.Attributes -UseMarkdown
 
                 foreach ($line in $propertyContent)
                 {
@@ -280,7 +280,7 @@ function New-DscResourceWikiPage
                     $resourceProperty += $propertyAttribute
                 }
 
-                $propertyContent = Get-DscResourceSchemaPropertyContent -Property $resourceProperty
+                $propertyContent = Get-DscResourceSchemaPropertyContent -Property $resourceProperty -UseMarkdown
 
                 foreach ($line in $propertyContent)
                 {

--- a/source/Public/New-DscResourceWikiPage.ps1
+++ b/source/Public/New-DscResourceWikiPage.ps1
@@ -4,24 +4,30 @@
         to use as public documentation for a module.
 
     .DESCRIPTION
-        The New-DscResourceWikiPage cmdlet will review all of the MOF based resources
-        in a specified module directory and will output the Markdown files to the
-        specified directory. These help files include details on the property types
-        for each resource, as well as a text description and examples where they exist.
+        The New-DscResourceWikiPage cmdlet will review all of the MOF-based and
+        class-based resources in a specified module directory and will output the
+        Markdown files to the specified directory. These help files include details
+        on the property types for each resource, as well as a text description and
+        examples where they exist.
 
     .PARAMETER OutputPath
-        Where should the files be saved to
+        Where should the files be saved to.
 
-    .PARAMETER ModulePath
+    .PARAMETER SourcePath
         The path to the root of the DSC resource module (where the PSD1 file is found,
-        not the folder for and individual DSC resource)
+        not the folder for and individual DSC resource).
+
+    .PARAMETER BuiltModulePath
+        The path to the root of the built DSC resource module, e.g.
+        'output/MyResource/1.0.0'.
 
     .EXAMPLE
         New-DscResourceWikiPage `
-            -ModulePath C:\repos\SharePointDsc\source `
-            -OutputPath C:\repos\SharePointDsc\output\WikiContent
+            -SourcePath C:\repos\MyResource\source `
+            -BuiltModulePath C:\repos\MyResource\output\MyResource\1.0.0 `
+            -OutputPath C:\repos\MyResource\output\WikiContent
 
-        This example shows how to generate help for a specific module
+        This example shows how to generate wiki documentation for a specific module.
 #>
 function New-DscResourceWikiPage
 {
@@ -34,13 +40,22 @@ function New-DscResourceWikiPage
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $ModulePath
+        $SourcePath,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $BuiltModulePath,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Force
     )
 
-    $mofSearchPath = Join-Path -Path $ModulePath -ChildPath '\**\*.schema.mof'
+    #region MOF-based resource
+    $mofSearchPath = Join-Path -Path $SourcePath -ChildPath '\**\*.schema.mof'
     $mofSchemaFiles = @(Get-ChildItem -Path $mofSearchPath -Recurse)
 
-    Write-Verbose -Message ($script:localizedData.FoundMofFilesMessage -f $mofSchemaFiles.Count, $ModulePath)
+    Write-Verbose -Message ($script:localizedData.FoundMofFilesMessage -f $mofSchemaFiles.Count, $SourcePath)
 
     # Loop through all the Schema files found in the modules folder
     foreach ($mofSchemaFile in $mofSchemaFiles)
@@ -113,30 +128,13 @@ function New-DscResourceWikiPage
             $null = $output.AppendLine()
             $null = $output.AppendLine($descriptionContent)
 
-            $exampleSearchPath = "\Examples\Resources\$($resourceSchema.FriendlyName)\*.ps1"
-            $examplesPath = (Join-Path -Path $ModulePath -ChildPath $exampleSearchPath)
-            $exampleFiles = @(Get-ChildItem -Path $examplesPath -ErrorAction SilentlyContinue)
+            $examplesPath = Join-Path -Path $SourcePath -ChildPath ('Examples\Resources\{0}' -f $resourceSchema.FriendlyName)
 
-            if ($exampleFiles.Count -gt 0)
+            $examplesOutput = Get-ResourceExampleAsMarkdown -Path $examplesPath
+
+            if($examplesOutput.Length -gt 0)
             {
-                $null = $output.AppendLine('## Examples')
-                $exampleCount = 1
-
-                foreach ($exampleFile in $exampleFiles)
-                {
-                    Write-Verbose -Message "Adding Example file '$($exampleFile.Name)' to wiki page for $($resourceSchema.FriendlyName)"
-
-                    $exampleContent = Get-DscResourceWikiExampleContent `
-                        -ExamplePath $exampleFile.FullName `
-                        -ExampleNumber ($exampleCount++)
-
-                    $null = $output.AppendLine()
-                    $null = $output.AppendLine($exampleContent)
-                }
-            }
-            else
-            {
-                Write-Warning -Message ($script:localizedData.NoExampleFileFoundWarning -f $resourceSchema.FriendlyName)
+                $null = $output.Append($examplesOutput)
             }
 
             $outputFileName = "$($resourceSchema.FriendlyName).md"
@@ -148,7 +146,7 @@ function New-DscResourceWikiPage
                 -InputObject ($output.ToString() -replace '\r?\n', "`r`n") `
                 -FilePath $savePath `
                 -Encoding utf8 `
-                -Force
+                -Force:$Force
         }
         elseif ($readmeFile.Count -gt 1)
         {
@@ -159,4 +157,173 @@ function New-DscResourceWikiPage
             Write-Warning -Message ($script:localizedData.NoDescriptionFileFoundWarning -f $resourceSchema.FriendlyName)
         }
     }
+    #endregion MOF-based resource
+
+    #region Class-based resource
+    if (Test-Path -Path $BuiltModulePath)
+    {
+        <#
+            This must not use Recurse. Then it could potentially find resources
+            that are part of common modules in the Modules folder.
+        #>
+        $getChildItemParameters = @{
+            Path        = Join-Path -Path $BuiltModulePath -ChildPath '*'
+            Include     = '*.psm1'
+            ErrorAction = 'Stop'
+            File        = $true
+        }
+
+        $builtModuleScriptFiles = Get-ChildItem @getChildItemParameters
+
+        # Looping through each module file (normally just one).
+        foreach ($builtModuleScriptFile in $builtModuleScriptFiles)
+        {
+            $tokens, $parseErrors = $null
+
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($builtModuleScriptFile.FullName, [ref] $tokens, [ref] $parseErrors)
+
+            if ($parseErrors)
+            {
+                throw $parseErrors
+            }
+
+            $astFilter = {
+                $args[0] -is [System.Management.Automation.Language.TypeDefinitionAst] `
+                    -and $args[0].IsClass -eq $true `
+                    -and $args[0].Attributes.Extent.Text -imatch '\[DscResource\(.*\)\]'
+            }
+
+            $dscResourceAsts = $ast.FindAll($astFilter, $true)
+
+            Write-Verbose -Message ($script:localizedData.FoundClassBasedMessage -f $dscResourceAsts.Count, $builtModuleScriptFile.FullName)
+
+            # Looping through each class-based resource.
+            foreach ($dscResourceAst in $dscResourceAsts)
+            {
+                Write-Verbose -Message ($script:localizedData.GenerateWikiPageMessage -f $dscResourceAst.Name)
+
+                $output = New-Object -TypeName 'System.Text.StringBuilder'
+
+                $null = $output.AppendLine("# $($dscResourceAst.Name)")
+                $null = $output.AppendLine()
+                $null = $output.AppendLine('## Parameters')
+                $null = $output.AppendLine()
+
+                $sourceFilePath = Join-Path -Path $SourcePath -ChildPath ('Classes/*{0}.ps1' -f $dscResourceAst.Name)
+
+                $dscResourceCommentBasedHelp = Get-ClassResourceCommentBasedHelp -Path $sourceFilePath
+
+                $astFilter = {
+                    $args[0] -is [System.Management.Automation.Language.PropertyMemberAst]
+                }
+
+                $propertyMemberAsts = $dscResourceAst.FindAll($astFilter, $true)
+
+                $resourceProperty = @()
+
+                <#
+                    Looping through each resource property to build the hashtable
+                    that should be passed to Get-DscResourceSchemaPropertyContent.
+                    Hashtable should be in the format:
+
+                    @{
+                        Name             = <System.String>
+                        State            = 'Key' | 'Required' |'Write' | 'Read'
+                        Description      = <System.String>
+                        EmbeddedInstance = 'MSFT_Credential' | $null
+                        DataType         = 'System.String' | 'System.String[] | etc.
+                        IsArray          = $true | $false
+                        ValueMap         = @(<System.String> | ...)
+                    }
+                #>
+                foreach ($propertyMemberAst in $propertyMemberAsts)
+                {
+                    Write-Verbose -Message ($script:localizedData.FoundClassResourcePropertyMessage -f $propertyMemberAst.Name, $dscResourceAst.Name)
+
+                    $propertyAttribute = @{
+                        Name             = $propertyMemberAst.Name
+                        DataType         = $propertyMemberAst.PropertyType.TypeName.FullName
+
+                        # Always set to null, correct type name is set in DataType.
+                        EmbeddedInstance = $null
+
+                        # Always set to $false - correct type name is set in DataType.
+                        IsArray          = $false
+                    }
+
+                    $propertyAttribute['State'] = Get-ClassResourcePropertyState -Ast $propertyMemberAst
+
+                    $astFilter = {
+                        $args[0] -is [System.Management.Automation.Language.AttributeAst] `
+                            -and $args[0].TypeName.Name -eq 'ValidateSet'
+                    }
+
+                    $propertyAttributeAsts = $propertyMemberAst.FindAll($astFilter, $true)
+
+                    if ($propertyAttributeAsts)
+                    {
+                        $propertyAttribute['ValueMap'] = $propertyAttributeAsts.PositionalArguments.Value
+                    }
+
+                    # The key name must be upper-case for it to match the right item in the list of parameters.
+                    $propertyDescription = ($dscResourceCommentBasedHelp.Parameters[$propertyMemberAst.Name.ToUpper()] -replace '[\r|\n]+$')
+
+                    $propertyDescription = $propertyDescription -replace '[\r|\n]+$' # Removes all blank rows at the end
+                    $propertyDescription = $propertyDescription -replace '[ ]+\r\n', "`r`n" # Remove indentation from blank rows
+                    $propertyDescription = $propertyDescription -replace '\r?\n', " " # Replace CRLF with one white space
+                    $propertyDescription = $propertyDescription -replace '\|', " " # Replace vertical bar with white space
+                    $propertyDescription = $propertyDescription -replace '  +', " " # Replace multiple whitespace with one single white space
+                    $propertyDescription = $propertyDescription -replace ' +$' # Remove white space from end of row
+
+                    $propertyAttribute['Description'] = $propertyDescription
+
+                    $resourceProperty += $propertyAttribute
+                }
+
+                $propertyContent = Get-DscResourceSchemaPropertyContent -Property $resourceProperty
+
+                foreach ($line in $propertyContent)
+                {
+                    $null = $output.AppendLine($line)
+                }
+
+                $null = $output.AppendLine()
+
+                $description = $dscResourceCommentBasedHelp.Description
+                $description = $description -replace '[\r|\n]+$' # Removes all blank rows and whitespace at the end
+
+                $null = $output.AppendLine('## Description')
+                $null = $output.AppendLine()
+                $null = $output.AppendLine($description)
+                $null = $output.AppendLine()
+
+                $examplesPath = Join-Path -Path $SourcePath -ChildPath ('Examples\Resources\{0}' -f $dscResourceAst.Name)
+
+                $examplesOutput = Get-ResourceExampleAsMarkdown -Path $examplesPath
+
+                if($examplesOutput.Length -gt 0)
+                {
+                    $null = $output.Append($examplesOutput)
+                }
+
+                $outputFileName = '{0}.md' -f $dscResourceAst.Name
+
+                $savePath = Join-Path -Path $OutputPath -ChildPath $outputFileName
+
+                Write-Verbose -Message ($script:localizedData.OutputWikiPageMessage -f $savePath)
+
+                $outputToWrite = $output.ToString()
+                $outputToWrite = $outputToWrite -replace '[\r|\n]+$' # Removes all blank rows and whitespace at the end
+                $outputToWrite = $outputToWrite -replace '\r?\n', "`r`n" # Normalize to CRLF
+                $outputToWrite = $outputToWrite -replace '[ ]+\r\n', "`r`n" # Remove indentation from blank rows
+
+                $null = Out-File `
+                    -InputObject $outputToWrite `
+                    -FilePath $savePath `
+                    -Encoding utf8 `
+                    -Force:$Force
+            }
+        }
+    }
+    #endregion Class-based resource
 }

--- a/source/Public/Split-ModuleVersion.ps1
+++ b/source/Public/Split-ModuleVersion.ps1
@@ -1,6 +1,6 @@
 <#
     .SYNOPSIS
-        This function parses a module version string as returns a hashtable
+        This function parses a module version string as returns a PSCustomObject
         which each of the module version's parts.
 
     .PARAMETER ModuleVersion
@@ -17,9 +17,8 @@
         1.15.0  pr0224           1.15.0-pr0224
 
     .NOTES
-        This is only used by Get-BuiltModuleVersion, so if the function in Sampler
-        is moved or exposed so we can remove Get-BuiltModuleVersion from this module
-        then we should remove this function too.
+        This is required by the function Get-BuiltModuleVersion and the build task
+        Generate_Wiki_Content.
 #>
 function Split-ModuleVersion
 {

--- a/source/en-US/DscResource.DocGenerator.strings.psd1
+++ b/source/en-US/DscResource.DocGenerator.strings.psd1
@@ -29,5 +29,5 @@ ConvertFrom-StringData @'
     FoundClassResourcePropertyMessage   = Found property '{0}' in the resource '{1}'.
     ClassBasedCommentBasedHelpMessage   = Reading comment-based help from source file '{0}'.
     FoundResourceExamplesMessage        = Found {0} examples.
-    IgnoreAstParseErrorMessage          = Errors was found during parsing of comment-based help. These errors was ignored: {0}
+    IgnoreAstParseErrorMessage          = Errors was found during parsing of comment-based help. These errors were ignored: {0}
 '@

--- a/source/en-US/DscResource.DocGenerator.strings.psd1
+++ b/source/en-US/DscResource.DocGenerator.strings.psd1
@@ -29,4 +29,5 @@ ConvertFrom-StringData @'
     FoundClassResourcePropertyMessage   = Found property '{0}' in the resource '{1}'.
     ClassBasedCommentBasedHelpMessage   = Reading comment-based help from source file '{0}'.
     FoundResourceExamplesMessage        = Found {0} examples.
+    IgnoreAstParseErrorMessage          = Errors was found during parsing of comment-based help. These errors was ignored: {0}
 '@

--- a/source/tasks/Generate_Wiki_Content.build.ps1
+++ b/source/tasks/Generate_Wiki_Content.build.ps1
@@ -140,7 +140,7 @@ task Generate_Wiki_Content {
 
     Write-Build -Color 'Magenta' -Text 'Generating Wiki content for all DSC resources based on source and built module.'
 
-    New-DscResourceWikiPage -SourcePath $SourcePath -BuiltModulePath $builtModulePath -OutputPath $wikiOutputPath
+    New-DscResourceWikiPage -SourcePath $SourcePath -BuiltModulePath $builtModulePath -OutputPath $wikiOutputPath -Force
 
     if ($wikiSourceExist)
     {

--- a/source/tasks/Generate_Wiki_Content.build.ps1
+++ b/source/tasks/Generate_Wiki_Content.build.ps1
@@ -110,6 +110,11 @@ task Generate_Wiki_Content {
 
     $moduleVersion = Get-BuiltModuleVersion @getBuiltModuleVersionParameters
 
+    $moduleVersionParts = Split-ModuleVersion -ModuleVersion $moduleVersion
+
+    $builtModulePath = Join-Path -Path $OutputDirectory -ChildPath $ProjectName |
+        Join-Path -ChildPath $moduleVersionParts.Version
+
     $wikiOutputPath = Join-Path -Path $OutputDirectory -ChildPath 'WikiContent'
 
     if ((Test-Path -Path $wikiOutputPath) -eq $false)
@@ -121,6 +126,7 @@ task Generate_Wiki_Content {
     "`tProject Name            = $ProjectName"
     "`tModule Version          = $moduleVersion"
     "`tSource Path             = $SourcePath"
+    "`tBuilt Module Path       = $builtModulePath"
     "`tWiki Output Path        = $wikiOutputPath"
 
     $wikiSourcePath = Join-Path -Path $SourcePath -ChildPath $WikiSourceFolderName
@@ -132,13 +138,13 @@ task Generate_Wiki_Content {
         "`tWiki Source Path        = $wikiSourcePath"
     }
 
-    Write-Build Magenta "Generating Wiki content for all DSC resources based on source."
+    Write-Build -Color 'Magenta' -Text 'Generating Wiki content for all DSC resources based on source and built module.'
 
-    New-DscResourceWikiPage -ModulePath $SourcePath -OutputPath $wikiOutputPath
+    New-DscResourceWikiPage -SourcePath $SourcePath -BuiltModulePath $builtModulePath -OutputPath $wikiOutputPath
 
     if ($wikiSourceExist)
     {
-        Write-Build Magenta "Copying Wiki content from the Wiki source folder."
+        Write-Build -Color 'Magenta' -Text 'Copying Wiki content from the Wiki source folder.'
 
         Copy-Item -Path (Join-Path $wikiSourcePath -ChildPath '*') -Destination $wikiOutputPath -Force
 
@@ -146,7 +152,7 @@ task Generate_Wiki_Content {
 
         if (Test-Path -Path $homeMarkdownFilePath)
         {
-            Write-Build Magenta "Updating module version in Home.md if there are any placeholders found."
+            Write-Build -Color 'Magenta' -Text 'Updating module version in Home.md if there are any placeholders found.'
 
             Set-WikiModuleVersion -Path $homeMarkdownFilePath -ModuleVersion $moduleVersion
         }

--- a/tests/helpers/DscResource.DocGenerator.TestHelper.psm1
+++ b/tests/helpers/DscResource.DocGenerator.TestHelper.psm1
@@ -40,7 +40,7 @@ function Out-Diff
         # Handle if expected is shorter than actual
         if (-not $expectedRow)
         {
-            $expectedRow = ''.PadRight($column1Width - 1)
+            $expectedRow = ''.PadRight($column1Width)
         }
 
         $diffIndicator = '  '

--- a/tests/helpers/DscResource.DocGenerator.TestHelper.psm1
+++ b/tests/helpers/DscResource.DocGenerator.TestHelper.psm1
@@ -1,0 +1,55 @@
+<#
+        .SYNOPSIS
+            This output two text blocks side-by-side in hex to easily
+            compare the diff.
+#>
+function Out-Diff
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $Actual,
+
+        [Parameter()]
+        [System.String]
+        $Expected
+    )
+
+    Write-Verbose -Message 'ERROR: Wrong output generated:' -Verbose
+
+    $expectedHex = $Expected | Format-Hex
+    $actualHex = $Actual | Format-Hex
+
+    $maxLength = @($expectedHex.length, $actualHex.length) |
+        Measure-Object -Maximum |
+        Select-Object -ExpandProperty 'Maximum'
+
+    $column1Width = ($expectedHex[0] -replace '\r?\n').Length
+
+    Write-Verbose -Message ("Expected:{0}But was:" -f ''.PadRight($column1Width - 1)) -Verbose
+
+    # Remove one since we start at 0.
+    $maxLength -= 1
+
+    0..$maxLength | ForEach-Object -Process {
+        $expectedRow = $expectedHex[$_] -replace '\r?\n'
+        $actualRow = $actualHex[$_] -replace '\r?\n'
+
+        # Handle if expected is shorter than actual
+        if (-not $expectedRow)
+        {
+            $expectedRow = ''.PadRight($column1Width - 1)
+        }
+
+        $diffIndicator = '  '
+
+        if ($expectedRow -ne $actualRow)
+        {
+            $diffIndicator = '!='
+        }
+
+        Write-Verbose -Message ("{0}   {1}   {2}" -f $expectedRow, $diffIndicator, $actualRow) -Verbose
+    }
+}

--- a/tests/helpers/DscResource.DocGenerator.TestHelper.psm1
+++ b/tests/helpers/DscResource.DocGenerator.TestHelper.psm1
@@ -1,7 +1,31 @@
 <#
-        .SYNOPSIS
-            This output two text blocks side-by-side in hex to easily
-            compare the diff.
+    .SYNOPSIS
+        This output two text blocks side-by-side in hex to easily
+        compare the diff.
+
+    .DESCRIPTION
+        This output two text blocks side-by-side in hex to easily
+        compare the diff. It is main intended use is as a helper for unit test
+        when comparing large text mass which can have small normally invisible
+        difference like an extra pch missing LF.
+
+    .PARAMETER Actual
+        A text string that should be compared against the text string that is passed
+        in parameter 'Expected'.
+
+    .PARAMETER Expected
+        A text string that should be compared against the text string that is passed
+        in parameter 'Actual'.
+
+    .EXAMPLE
+        Out-Diff `
+            -Expected 'This is a longer text string that was expected to be shown' `
+            -Actual 'This is the actual text string'
+
+    .NOTES
+        This outputs the lines in verbose statements because it is the easiest way
+        to show output when running tests in Pester. The output is wide, 185 characters,
+        to get the best side-by-side comparison.
 #>
 function Out-Diff
 {
@@ -17,7 +41,7 @@ function Out-Diff
         $Expected
     )
 
-    Write-Verbose -Message 'ERROR: Wrong output generated:' -Verbose
+    Write-Verbose -Message 'UNEXPECTED RESULT GENERATED:' -Verbose
 
     $expectedHex = $Expected | Format-Hex
     $actualHex = $Actual | Format-Hex

--- a/tests/unit/private/Get-ClassResourceCommentBasedHelp.Tests.ps1
+++ b/tests/unit/private/Get-ClassResourceCommentBasedHelp.Tests.ps1
@@ -49,11 +49,10 @@ class AzDevOpsProject
                 { Get-ClassResourceCommentBasedHelp -Path $mockFilePath -Verbose } | Should -Throw 'The DSC resource ''AzDevOpsProject'' is missing a Set method that returns [void] and accepts no parameters.'
             }
         }
-    }
 
-    Context 'When returning comment-based help' {
-        BeforeAll {
-            $mockScriptFileContent = @'
+        Context 'When returning comment-based help' {
+            BeforeAll {
+                $mockScriptFileContent = @'
 <#
 .SYNOPSIS
     A synopsis.
@@ -83,15 +82,16 @@ class AzDevOpsProject
     [System.String]$ProjectName
 }
 '@
-            $mockFilePath = Join-Path -Path $TestDrive -ChildPath 'MyClassResource.ps1'
-            $mockScriptFileContent | Out-File -FilePath $mockFilePath -Encoding ascii -Force
-        }
+                $mockFilePath = Join-Path -Path $TestDrive -ChildPath 'MyClassResource.ps1'
+                $mockScriptFileContent | Out-File -FilePath $mockFilePath -Encoding ascii -Force
+            }
 
-        It 'Should return the correct comment-based help' {
-            $result = Get-ClassResourceCommentBasedHelp -Path $mockFilePath -Verbose
+            It 'Should return the correct comment-based help' {
+                $result = Get-ClassResourceCommentBasedHelp -Path $mockFilePath -Verbose
 
-            # Parameter name must be upper-case. Also strip any new lines at the end of the string.
-            ($result.Parameters['PROJECTNAME'] -replace '\r?\n+$') | Should -Be 'ProjectName description.'
+                # Parameter name must be upper-case. Also strip any new lines at the end of the string.
+                ($result.Parameters['PROJECTNAME'] -replace '\r?\n+$') | Should -Be 'ProjectName description.'
+            }
         }
     }
 }

--- a/tests/unit/private/Get-ClassResourceCommentBasedHelp.Tests.ps1
+++ b/tests/unit/private/Get-ClassResourceCommentBasedHelp.Tests.ps1
@@ -45,28 +45,14 @@ class AzDevOpsProject
                 $mockScriptFileContent | Out-File -FilePath $mockFilePath -Encoding ascii -Force
 
                 Mock -CommandName Write-Debug
-
-                <#
-                    The blank rows are intentionally as the parse error record that
-                    is returned have them. The string is normalize to CRLF to
-                    handle cross-plattform testing.
-                #>
-                $mockWriteDebugOutput = @'
-
-Extent          ErrorId                     Message                                                                                                   IncompleteInput
-------          -------                     -------                                                                                                   ---------------
-[DscResource()] DscResourceMissingSetMethod The DSC resource 'AzDevOpsProject' is missing a Set method that returns [void] and accepts no parameters.           False
-
-
-'@ -replace '\r?\n', "`r`n"
             }
 
             It 'Should not throw an exception and call the correct mock' {
                 { Get-ClassResourceCommentBasedHelp -Path $mockFilePath -Verbose } | Should -Not -Throw
 
                 Assert-MockCalled -CommandName Write-Debug -ParameterFilter {
-                    # Normalize the message to CRLF to handle cross-plattform testing.
-                    ($Message -replace '\r?\n', "`r`n") -eq ($script:localizedData.IgnoreAstParseErrorMessage -f $mockWriteDebugOutput)
+                    # Assert the localized string is part of the message
+                    $Message -match [System.Text.RegularExpressions.RegEx]::Escape($script:localizedData.IgnoreAstParseErrorMessage -f '')
                 } -Exactly -Times 1 -Scope It
             }
         }

--- a/tests/unit/private/Get-ClassResourceCommentBasedHelp.Tests.ps1
+++ b/tests/unit/private/Get-ClassResourceCommentBasedHelp.Tests.ps1
@@ -43,10 +43,31 @@ class AzDevOpsProject
 '@
                 $mockFilePath = Join-Path -Path $TestDrive -ChildPath 'MyClassResource.ps1'
                 $mockScriptFileContent | Out-File -FilePath $mockFilePath -Encoding ascii -Force
+
+                Mock -CommandName Write-Debug
+
+                <#
+                    The blank rows are intentionally as the parse error record that
+                    is returned have them. The string is normalize to CRLF to
+                    handle cross-plattform testing.
+                #>
+                $mockWriteDebugOutput = @'
+
+Extent          ErrorId                     Message                                                                                                   IncompleteInput
+------          -------                     -------                                                                                                   ---------------
+[DscResource()] DscResourceMissingSetMethod The DSC resource 'AzDevOpsProject' is missing a Set method that returns [void] and accepts no parameters.           False
+
+
+'@ -replace '\r?\n', "`r`n"
             }
 
-            It 'Should throw an error' {
-                { Get-ClassResourceCommentBasedHelp -Path $mockFilePath -Verbose } | Should -Throw 'The DSC resource ''AzDevOpsProject'' is missing a Set method that returns [void] and accepts no parameters.'
+            It 'Should not throw an exception and call the correct mock' {
+                { Get-ClassResourceCommentBasedHelp -Path $mockFilePath -Verbose } | Should -Not -Throw
+
+                Assert-MockCalled -CommandName Write-Debug -ParameterFilter {
+                    # Normalize the message to CRLF to handle cross-plattform testing.
+                    ($Message -replace '\r?\n', "`r`n") -eq ($script:localizedData.IgnoreAstParseErrorMessage -f $mockWriteDebugOutput)
+                } -Exactly -Times 1 -Scope It
             }
         }
 

--- a/tests/unit/private/Get-ClassResourceCommentBasedHelp.Tests.ps1
+++ b/tests/unit/private/Get-ClassResourceCommentBasedHelp.Tests.ps1
@@ -1,0 +1,97 @@
+#region HEADER
+$script:projectPath = "$PSScriptRoot\..\..\.." | Convert-Path
+$script:projectName = (Get-ChildItem -Path "$script:projectPath\*\*.psd1" | Where-Object -FilterScript {
+        ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+        $(try
+            {
+                Test-ModuleManifest -Path $_.FullName -ErrorAction Stop
+            }
+            catch
+            {
+                $false
+            })
+    }).BaseName
+
+$script:moduleName = Get-Module -Name $script:projectName -ListAvailable | Select-Object -First 1
+Remove-Module -Name $script:moduleName -Force -ErrorAction 'SilentlyContinue'
+
+Import-Module $script:moduleName -Force -ErrorAction 'Stop'
+#endregion HEADER
+
+InModuleScope $script:moduleName {
+    Describe 'Get-ClassResourceCommentBasedHelp' {
+        Context 'When there is a script parse error' {
+            BeforeAll {
+                # Mock script have not declared a Set-method.
+                $mockScriptFileContent = @'
+[DscResource()]
+class AzDevOpsProject
+{
+    [AzDevOpsProject] Get()
+    {
+        return [AzDevOpsProject] $this
+    }
+
+    [System.Boolean] Test()
+    {
+        return $true
+    }
+
+    [DscProperty(Key)]
+    [System.String]$ProjectName
+}
+'@
+                $mockFilePath = Join-Path -Path $TestDrive -ChildPath 'MyClassResource.ps1'
+                $mockScriptFileContent | Out-File -FilePath $mockFilePath -Encoding ascii -Force
+            }
+
+            It 'Should throw an error' {
+                { Get-ClassResourceCommentBasedHelp -Path $mockFilePath -Verbose } | Should -Throw 'The DSC resource ''AzDevOpsProject'' is missing a Set method that returns [void] and accepts no parameters.'
+            }
+        }
+    }
+
+    Context 'When returning comment-based help' {
+        BeforeAll {
+            $mockScriptFileContent = @'
+<#
+.SYNOPSIS
+    A synopsis.
+
+.DESCRIPTION
+    A description.
+
+.PARAMETER ProjectName
+    ProjectName description.
+#>
+[DscResource()]
+class AzDevOpsProject
+{
+    [AzDevOpsProject] Get()
+    {
+        return [AzDevOpsProject] $this
+    }
+
+    [System.Boolean] Test()
+    {
+        return $true
+    }
+
+    [void] Set() {}
+
+    [DscProperty(Key)]
+    [System.String]$ProjectName
+}
+'@
+            $mockFilePath = Join-Path -Path $TestDrive -ChildPath 'MyClassResource.ps1'
+            $mockScriptFileContent | Out-File -FilePath $mockFilePath -Encoding ascii -Force
+        }
+
+        It 'Should return the correct comment-based help' {
+            $result = Get-ClassResourceCommentBasedHelp -Path $mockFilePath -Verbose
+
+            # Parameter name must be upper-case. Also strip any new lines at the end of the string.
+            ($result.Parameters['PROJECTNAME'] -replace '\r?\n+$') | Should -Be 'ProjectName description.'
+        }
+    }
+}

--- a/tests/unit/private/Get-ClassResourcePropertyState.Tests.ps1
+++ b/tests/unit/private/Get-ClassResourcePropertyState.Tests.ps1
@@ -1,0 +1,191 @@
+#region HEADER
+$script:projectPath = "$PSScriptRoot\..\..\.." | Convert-Path
+$script:projectName = (Get-ChildItem -Path "$script:projectPath\*\*.psd1" | Where-Object -FilterScript {
+        ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+        $(try
+            {
+                Test-ModuleManifest -Path $_.FullName -ErrorAction Stop
+            }
+            catch
+            {
+                $false
+            })
+    }).BaseName
+
+$script:moduleName = Get-Module -Name $script:projectName -ListAvailable | Select-Object -First 1
+Remove-Module -Name $script:moduleName -Force -ErrorAction 'SilentlyContinue'
+
+Import-Module $script:moduleName -Force -ErrorAction 'Stop'
+#endregion HEADER
+
+InModuleScope $script:moduleName {
+    Describe 'Get-ClassResourcePropertyState' {
+        Context 'When a property have the named attribute argument ''Key''' {
+            BeforeAll {
+                $mockClassBasedScript = {
+                    [DscResource()]
+                    class AzDevOpsProject
+                    {
+                        [AzDevOpsProject] Get()
+                        {
+                            return [AzDevOpsProject] $this
+                        }
+
+                        [System.Boolean] Test()
+                        {
+                            return $true
+                        }
+
+                        [void] Set()
+                        {
+                        }
+
+                        [DscProperty(Key)]
+                        [System.String] $ProjectName
+                    }
+                }
+
+                $astFilter = {
+                    $args[0] -is [System.Management.Automation.Language.PropertyMemberAst]
+                }
+
+                $propertyMemberAst = $mockClassBasedScript.Ast.FindAll($astFilter, $false)
+            }
+
+            It 'Should return the state as ''Key''' {
+                $result = Get-ClassResourcePropertyState -Ast $propertyMemberAst[0] -Verbose
+
+                $result | Should -Be 'Key'
+            }
+        }
+
+        Context 'When a property have no named attribute argument' {
+            BeforeAll {
+                $mockClassBasedScript = {
+                    [DscResource()]
+                    class AzDevOpsProject
+                    {
+                        [AzDevOpsProject] Get()
+                        {
+                            return [AzDevOpsProject] $this
+                        }
+
+                        [System.Boolean] Test()
+                        {
+                            return $true
+                        }
+
+                        [void] Set()
+                        {
+                        }
+
+                        [DscProperty(Key)]
+                        [System.String] $ProjectName
+
+                        [DscProperty()]
+                        [System.String] $ProjectId
+                    }
+                }
+
+                $astFilter = {
+                    $args[0] -is [System.Management.Automation.Language.PropertyMemberAst]
+                }
+
+                $propertyMemberAst = $mockClassBasedScript.Ast.FindAll($astFilter, $false)
+            }
+
+            It 'Should return the state as ''Write''' {
+                # Makes sure to test the second property (since Key is always needed)
+                $result = Get-ClassResourcePropertyState -Ast $propertyMemberAst[1] -Verbose
+
+                $result | Should -Be 'Write'
+            }
+        }
+
+        Context 'When a property have the named attribute argument ''Mandatory''' {
+            BeforeAll {
+                $mockClassBasedScript = {
+                    [DscResource()]
+                    class AzDevOpsProject
+                    {
+                        [AzDevOpsProject] Get()
+                        {
+                            return [AzDevOpsProject] $this
+                        }
+
+                        [System.Boolean] Test()
+                        {
+                            return $true
+                        }
+
+                        [void] Set()
+                        {
+                        }
+
+                        [DscProperty(Key)]
+                        [System.String] $ProjectName
+
+                        [DscProperty(Mandatory)]
+                        [System.String] $ProjectId
+                    }
+                }
+
+                $astFilter = {
+                    $args[0] -is [System.Management.Automation.Language.PropertyMemberAst]
+                }
+
+                $propertyMemberAst = $mockClassBasedScript.Ast.FindAll($astFilter, $false)
+            }
+
+            It 'Should return the state as ''Required''' {
+                # Makes sure to test the second property (since Key is always needed)
+                $result = Get-ClassResourcePropertyState -Ast $propertyMemberAst[1] -Verbose
+
+                $result | Should -Be 'Required'
+            }
+        }
+
+        Context 'When a property have the named attribute argument ''NotConfigurable''' {
+            BeforeAll {
+                $mockClassBasedScript = {
+                    [DscResource()]
+                    class AzDevOpsProject
+                    {
+                        [AzDevOpsProject] Get()
+                        {
+                            return [AzDevOpsProject] $this
+                        }
+
+                        [System.Boolean] Test()
+                        {
+                            return $true
+                        }
+
+                        [void] Set()
+                        {
+                        }
+
+                        [DscProperty(Key)]
+                        [System.String] $ProjectName
+
+                        [DscProperty(NotConfigurable)]
+                        [System.String] $ProjectId
+                    }
+                }
+
+                $astFilter = {
+                    $args[0] -is [System.Management.Automation.Language.PropertyMemberAst]
+                }
+
+                $propertyMemberAst = $mockClassBasedScript.Ast.FindAll($astFilter, $false)
+            }
+
+            It 'Should return the state as ''Read''' {
+                # Makes sure to test the second property (since Key is always needed)
+                $result = Get-ClassResourcePropertyState -Ast $propertyMemberAst[1] -Verbose
+
+                $result | Should -Be 'Read'
+            }
+        }
+    }
+}

--- a/tests/unit/private/Get-ResourceExampleAsMarkdown.Tests.ps1
+++ b/tests/unit/private/Get-ResourceExampleAsMarkdown.Tests.ps1
@@ -1,0 +1,60 @@
+#region HEADER
+$script:projectPath = "$PSScriptRoot\..\..\.." | Convert-Path
+$script:projectName = (Get-ChildItem -Path "$script:projectPath\*\*.psd1" | Where-Object -FilterScript {
+        ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+        $(try
+            {
+                Test-ModuleManifest -Path $_.FullName -ErrorAction Stop
+            }
+            catch
+            {
+                $false
+            })
+    }).BaseName
+
+$script:moduleName = Get-Module -Name $script:projectName -ListAvailable | Select-Object -First 1
+Remove-Module -Name $script:moduleName -Force -ErrorAction 'SilentlyContinue'
+
+Import-Module $script:moduleName -Force -ErrorAction 'Stop'
+#endregion HEADER
+
+InModuleScope $script:moduleName {
+    Describe 'Get-ResourceExampleAsMarkdown' {
+        Context 'When there are no examples for a resource' {
+            BeforeAll {
+                Mock -CommandName Get-ChildItem
+                Mock -CommandName Write-Warning
+            }
+
+            It 'Should not throw and write a warning message' {
+                 { Get-ResourceExampleAsMarkdown -Path $TestDrive } | Should -Not -Throw
+
+                 Assert-MockCalled -CommandName Write-Warning -ParameterFilter {
+                    $Message -eq ($script:localizedData.NoExampleFileFoundWarning -f 'MyResource')
+                 } -Exactly -Times 1 -Scope It
+            }
+        }
+
+        Context 'When there are ' {
+            BeforeAll {
+                $mockExamplePath = Join-Path $TestDrive -ChildPath 'Example1.ps1'
+
+                Mock -CommandName Get-DscResourceWikiExampleContent
+                Mock -CommandName Get-ChildItem -MockWith {
+                    return @{
+                        FullName = $mockExamplePath
+                    }
+                }
+            }
+
+            It 'Should not throw and call the correct mock to generate the output' {
+                { Get-ResourceExampleAsMarkdown -Path $TestDrive } | Should -Not -Throw
+
+                Assert-MockCalled -CommandName Get-DscResourceWikiExampleContent -ParameterFilter {
+                   $ExamplePath -eq $mockExamplePath `
+                   -and $ExampleNumber -eq 1
+                } -Exactly -Times 1 -Scope It
+           }
+        }
+    }
+}

--- a/tests/unit/private/Test-PropertyMemberAst.Tests.ps1
+++ b/tests/unit/private/Test-PropertyMemberAst.Tests.ps1
@@ -1,0 +1,242 @@
+#region HEADER
+$script:projectPath = "$PSScriptRoot\..\..\.." | Convert-Path
+$script:projectName = (Get-ChildItem -Path "$script:projectPath\*\*.psd1" | Where-Object -FilterScript {
+        ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+        $(try
+            {
+                Test-ModuleManifest -Path $_.FullName -ErrorAction Stop
+            }
+            catch
+            {
+                $false
+            })
+    }).BaseName
+
+$script:moduleName = Get-Module -Name $script:projectName -ListAvailable | Select-Object -First 1
+Remove-Module -Name $script:moduleName -Force -ErrorAction 'SilentlyContinue'
+
+Import-Module $script:moduleName -Force -ErrorAction 'Stop'
+#endregion HEADER
+
+InModuleScope $script:moduleName {
+    Describe 'Get-ClassResourcePropertyState' {
+        Context 'When testing if a property is ''Key''' {
+            BeforeAll {
+                $mockClassBasedScript = {
+                    [DscResource()]
+                    class AzDevOpsProject
+                    {
+                        [AzDevOpsProject] Get()
+                        {
+                            return [AzDevOpsProject] $this
+                        }
+
+                        [System.Boolean] Test()
+                        {
+                            return $true
+                        }
+
+                        [void] Set()
+                        {
+                        }
+
+                        [DscProperty(Key)]
+                        [System.String] $ProjectName
+                    }
+                }
+
+                $astFilter = {
+                    $args[0] -is [System.Management.Automation.Language.PropertyMemberAst]
+                }
+
+                $propertyMemberAst = $mockClassBasedScript.Ast.FindAll($astFilter, $false)
+            }
+
+            It 'Should return $true' {
+                $result = Test-PropertyMemberAst -Ast $propertyMemberAst[0] -IsKey
+
+                $result | Should -BeTrue
+            }
+
+            Context 'When testing if a Key property is mandatory' {
+                It 'Should return $true' {
+                    $result = Test-PropertyMemberAst -Ast $propertyMemberAst[0] -IsMandatory
+
+                    $result | Should -BeTrue
+                }
+            }
+        }
+
+        Context 'When testing if a property is ''Write''' {
+            BeforeAll {
+                $mockClassBasedScript = {
+                    [DscResource()]
+                    class AzDevOpsProject
+                    {
+                        [AzDevOpsProject] Get()
+                        {
+                            return [AzDevOpsProject] $this
+                        }
+
+                        [System.Boolean] Test()
+                        {
+                            return $true
+                        }
+
+                        [void] Set()
+                        {
+                        }
+
+                        [DscProperty(Key)]
+                        [System.String] $ProjectName
+
+                        [DscProperty()]
+                        [System.String] $ProjectId
+                    }
+                }
+
+                $astFilter = {
+                    $args[0] -is [System.Management.Automation.Language.PropertyMemberAst]
+                }
+
+                $propertyMemberAst = $mockClassBasedScript.Ast.FindAll($astFilter, $false)
+            }
+
+            It 'Should return $true' {
+                # Makes sure to test the second property (since Key is always needed)
+                $result = Test-PropertyMemberAst -Ast $propertyMemberAst[1] -IsWrite
+
+                $result | Should -BeTrue
+            }
+        }
+
+        Context 'When testing if a property is ''Mandatory''' {
+            BeforeAll {
+                $mockClassBasedScript = {
+                    [DscResource()]
+                    class AzDevOpsProject
+                    {
+                        [AzDevOpsProject] Get()
+                        {
+                            return [AzDevOpsProject] $this
+                        }
+
+                        [System.Boolean] Test()
+                        {
+                            return $true
+                        }
+
+                        [void] Set()
+                        {
+                        }
+
+                        [DscProperty(Key)]
+                        [System.String] $ProjectName
+
+                        [DscProperty(Mandatory)]
+                        [System.String] $ProjectId
+                    }
+                }
+
+                $astFilter = {
+                    $args[0] -is [System.Management.Automation.Language.PropertyMemberAst]
+                }
+
+                $propertyMemberAst = $mockClassBasedScript.Ast.FindAll($astFilter, $false)
+            }
+
+            It 'Should return $true' {
+                # Makes sure to test the second property (since Key is always needed)
+                $result = Test-PropertyMemberAst -Ast $propertyMemberAst[1] -IsMandatory
+
+                $result | Should -BeTrue
+            }
+        }
+
+        Context 'When testing if a property is ''Read''' {
+            BeforeAll {
+                $mockClassBasedScript = {
+                    [DscResource()]
+                    class AzDevOpsProject
+                    {
+                        [AzDevOpsProject] Get()
+                        {
+                            return [AzDevOpsProject] $this
+                        }
+
+                        [System.Boolean] Test()
+                        {
+                            return $true
+                        }
+
+                        [void] Set()
+                        {
+                        }
+
+                        [DscProperty(Key)]
+                        [System.String] $ProjectName
+
+                        [DscProperty(NotConfigurable)]
+                        [System.String] $ProjectId
+                    }
+                }
+
+                $astFilter = {
+                    $args[0] -is [System.Management.Automation.Language.PropertyMemberAst]
+                }
+
+                $propertyMemberAst = $mockClassBasedScript.Ast.FindAll($astFilter, $false)
+            }
+
+            It 'Should return $true' {
+                # Makes sure to test the second property (since Key is always needed)
+                $result = Test-PropertyMemberAst -Ast $propertyMemberAst[1] -IsRead
+
+                $result | Should -BeTrue
+            }
+        }
+
+        Context 'When testing if a property have the expected State property but it does not' {
+            BeforeAll {
+                $mockClassBasedScript = {
+                    [DscResource()]
+                    class AzDevOpsProject
+                    {
+                        [AzDevOpsProject] Get()
+                        {
+                            return [AzDevOpsProject] $this
+                        }
+
+                        [System.Boolean] Test()
+                        {
+                            return $true
+                        }
+
+                        [void] Set()
+                        {
+                        }
+
+                        [DscProperty(Key)]
+                        [System.String] $ProjectName
+
+                        [DscProperty(NotConfigurable)]
+                        [System.String] $ProjectId
+                    }
+                }
+
+                $astFilter = {
+                    $args[0] -is [System.Management.Automation.Language.PropertyMemberAst]
+                }
+
+                $propertyMemberAst = $mockClassBasedScript.Ast.FindAll($astFilter, $false)
+            }
+
+            It 'Should return $false' {
+                # Makes sure to test the second property (since Key is always needed)
+                $result = Test-PropertyMemberAst -Ast $propertyMemberAst[0] -IsRead
+
+                $result | Should -BeFalse
+            }
+        }
+    }
+}

--- a/tests/unit/public/New-DscResourcePowerShellHelp.Tests.ps1
+++ b/tests/unit/public/New-DscResourcePowerShellHelp.Tests.ps1
@@ -18,6 +18,8 @@ Remove-Module -Name $script:moduleName -Force -ErrorAction 'SilentlyContinue'
 Import-Module $script:moduleName -Force -ErrorAction 'Stop'
 #endregion HEADER
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '../../helpers/DscResource.DocGenerator.TestHelper.psm1') -Force
+
 InModuleScope $script:moduleName {
     <#
         .NOTES
@@ -56,62 +58,6 @@ InModuleScope $script:moduleName {
         )
 
         throw 'StubNotImplemented'
-    }
-
-    <#
-        .SYNOPSIS
-            This output two text blocks side-by-side in hex to easily
-            compare the diff.
-    #>
-    function Out-Diff
-    {
-        [CmdletBinding()]
-        param
-        (
-            [Parameter()]
-            [System.String]
-            $Actual,
-
-            [Parameter()]
-            [System.String]
-            $Expected
-        )
-
-        Write-Verbose -Message 'ERROR: Wrong output generated:' -Verbose
-
-        $expectedHex = $Expected | Format-Hex
-        $actualHex = $Actual | Format-Hex
-
-        $maxLength = @($expectedHex.length, $actualHex.length) |
-            Measure-Object -Maximum |
-            Select-Object -ExpandProperty 'Maximum'
-
-        $column1Width = ($expectedHex[0] -replace '\r?\n').Length
-
-        Write-Verbose -Message ("Expected:{0}But was:" -f ''.PadRight($column1Width - 1)) -Verbose
-
-        # Remove one since we start at 0.
-        $maxLength -= 1
-
-        0..$maxLength | ForEach-Object -Process {
-            $expectedRow = $expectedHex[$_] -replace '\r?\n'
-            $actualRow = $actualHex[$_] -replace '\r?\n'
-
-            # Handle if expected is shorter than actual
-            if (-not $expectedRow)
-            {
-                $expectedRow = ''.PadRight($column1Width - 1)
-            }
-
-            $diffIndicator = '  '
-
-            if ($expectedRow -ne $actualRow)
-            {
-                $diffIndicator = '!='
-            }
-
-            Write-Verbose -Message ("{0}   {1}   {2}" -f $expectedRow, $diffIndicator, $actualRow) -Verbose
-        }
     }
 
     Describe 'New-DscResourcePowerShellHelp' {
@@ -1053,6 +999,20 @@ class AzDevOpsProject
 [DscResource()]
 class AzDevOpsProject
 {
+    [AzDevOpsProject] Get()
+    {
+        return [AzDevOpsProject] $this
+    }
+
+    [System.Boolean] Test()
+    {
+        return $true
+    }
+
+    [void] Set() {}
+
+    [DscProperty(Key)]
+    [System.String]$ProjectName
 }
 '@
                     # Uses Microsoft.PowerShell.Utility\Out-File to override the stub that is needed for the mocks.
@@ -1182,6 +1142,20 @@ class AzDevOpsProject
 [DscResource()]
 class AzDevOpsProject
 {
+    [AzDevOpsProject] Get()
+    {
+        return [AzDevOpsProject] $this
+    }
+
+    [System.Boolean] Test()
+    {
+        return $true
+    }
+
+    [void] Set() {}
+
+    [DscProperty(Key)]
+    [System.String]$ProjectName
 }
 '@
                     # Uses Microsoft.PowerShell.Utility\Out-File to override the stub that is needed for the mocks.
@@ -1266,6 +1240,20 @@ class AzDevOpsProject
 [DscResource()]
 class AzDevOpsProject
 {
+    [AzDevOpsProject] Get()
+    {
+        return [AzDevOpsProject] $this
+    }
+
+    [System.Boolean] Test()
+    {
+        return $true
+    }
+
+    [void] Set() {}
+
+    [DscProperty(Key)]
+    [System.String]$ProjectName
 }
 '@
                     # Uses Microsoft.PowerShell.Utility\Out-File to override the stub that is needed for the mocks.
@@ -1425,6 +1413,33 @@ class AzDevOpsProject
 [DscResource()]
 class AzDevOpsProject
 {
+    [AzDevOpsProject] Get()
+    {
+        return [AzDevOpsProject] $this
+    }
+
+    [System.Boolean] Test()
+    {
+        return $true
+    }
+
+    [void] Set() {}
+
+    [DscProperty(Key)]
+    [System.String]$ProjectName
+
+    [DscProperty()]
+    [System.String]$ProjectId
+
+    [DscProperty()]
+    [ValidateSet('Up', 'Down')]
+    [System.String]$ValidateSetProperty
+
+    [DscProperty(Mandatory)]
+    [System.String]$MandatoryProperty
+
+    [DscProperty(NotConfigurable)]
+    [String[]]$Reasons
 }
 '@
                     # Uses Microsoft.PowerShell.Utility\Out-File to override the stub that is needed for the mocks.
@@ -1540,6 +1555,20 @@ class AzDevOpsProject
 [DscResource()]
 class AzDevOpsProject
 {
+    [AzDevOpsProject] Get()
+    {
+        return [AzDevOpsProject] $this
+    }
+
+    [System.Boolean] Test()
+    {
+        return $true
+    }
+
+    [void] Set() {}
+
+    [DscProperty(Key)]
+    [System.String]$ProjectName
 }
 '@
                     # Uses Microsoft.PowerShell.Utility\Out-File to override the stub that is needed for the mocks.

--- a/tests/unit/public/New-DscResourceWikiPage.Tests.ps1
+++ b/tests/unit/public/New-DscResourceWikiPage.Tests.ps1
@@ -159,14 +159,14 @@ Configuration Example
 The description of the resource.
 Second row of description.
 '
-            $script:mockWikiContentOutput = "# MyResource
+            $script:mockWikiContentOutput = '# MyResource
 
 ## Parameters
 
 | Parameter | Attribute | DataType | Description | Allowed Values |
 | --- | --- | --- | --- | --- |
 | **Id** | Key | String | Id Description | |
-| **Enum** | Write | String | Enum Description. | Value1, Value2, Value3 |
+| **Enum** | Write | String | Enum Description. | `Value1`, `Value2`, `Value3` |
 | **Int** | Required | Uint32 | Int Description. | |
 | **Read** | Read | String | Read Description. | |
 
@@ -188,13 +188,13 @@ Configuration Example
     {
         MyResource Something
         {
-            Id    = 'MyId'
-            Enum  = 'Value1'
+            Id    = ''MyId''
+            Enum  = ''Value1''
             Int   = 1
         }
     }
 }
-" -replace '\r?\n', "`r`n"
+' -replace '\r?\n', "`r`n"
 
             # Parameter filters
             $script:getChildItemSchema_parameterFilter = {
@@ -229,14 +229,14 @@ Configuration Example
                 $FilePath -eq $script:mockSavePath
             }
 
-            $script:outFileInputObject_parameterFilter = {
-                $InputObject -eq $script:mockWikiContentOutput -and
-                $FilePath -eq $script:mockSavePath
-            }
+            $script:outFileContent_parameterFilter = {
+                if ($InputObject -ne $script:mockWikiContentOutput)
+                {
+                    # Helper to output the diff.
+                    Out-Diff -Expected $script:mockWikiContentOutput -Actual $InputObject
+                }
 
-            $script:outFileOutputInputObject_parameterFilter = {
-                $InputObject -eq $script:mockWikiContentOutput -and
-                $FilePath -eq $script:mockSavePath
+                $InputObject -eq $script:mockWikiContentOutput
             }
 
             $script:writeWarningDescription_parameterFilter = {
@@ -359,9 +359,18 @@ Configuration Example
                     Mock `
                         -CommandName Get-ChildItem `
                         -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                        -MockWith { return @(
-                            @{ Name = 'README.MD'; FullName = $script:mockReadmePath },
-                            @{ Name = 'Readme.md'; FullName = $script:mockReadmePath }) }
+                        -MockWith {
+                            return @(
+                                @{
+                                    Name = 'README.MD'
+                                    FullName = $script:mockReadmePath
+                                },
+                                @{
+                                    Name = 'Readme.md'
+                                    FullName = $script:mockReadmePath
+                                }
+                            )
+                        }
 
                     Mock `
                         -CommandName Out-File `
@@ -414,7 +423,14 @@ Configuration Example
                     Mock `
                         -CommandName Get-ChildItem `
                         -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                        -MockWith { return @(@{ Name = 'README.MD'; FullName = $script:mockReadmePath }) }
+                        -MockWith {
+                            return @(
+                                @{
+                                    Name = 'README.MD'
+                                    FullName = $script:mockReadmePath
+                                }
+                            )
+                        }
 
                     Mock `
                         -CommandName Get-Content `
@@ -499,8 +515,14 @@ Configuration Example
                     Mock `
                         -CommandName Get-ChildItem `
                         -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                        -MockWith { return @(@{ Name = 'README.MD'; FullName = $script:mockReadmePath }) }
-
+                        -MockWith {
+                            return @(
+                                @{
+                                    Name = 'README.MD'
+                                    FullName = $script:mockReadmePath
+                                }
+                            )
+                        }
 
                     Mock `
                         -CommandName Get-Content `
@@ -536,7 +558,12 @@ Configuration Example
                 It 'Should produce the correct output' {
                     Assert-MockCalled `
                         -CommandName Out-File `
-                        -ParameterFilter $script:outFileOutputInputObject_parameterFilter `
+                        -ParameterFilter $script:outFileContent_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Out-File `
+                        -ParameterFilter $script:outFile_parameterFilter `
                         -Exactly -Times 1
                 }
 
@@ -598,7 +625,14 @@ Configuration Example
                     Mock `
                         -CommandName Get-ChildItem `
                         -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                        -MockWith { return @(@{ Name = 'README.MD'; FullName = $script:mockReadmePath }) }
+                        -MockWith {
+                            return @(
+                                @{
+                                    Name = 'README.MD'
+                                    FullName = $script:mockReadmePath
+                                }
+                            )
+                        }
 
                     Mock `
                         -CommandName Get-Content `
@@ -634,7 +668,12 @@ Configuration Example
                 It 'Should produce the correct output' {
                     Assert-MockCalled `
                         -CommandName Out-File `
-                        -ParameterFilter $script:outFileInputObject_parameterFilter `
+                        -ParameterFilter $script:outFileContent_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Out-File `
+                        -ParameterFilter $script:outFile_parameterFilter `
                         -Exactly -Times 1
                 }
 
@@ -732,14 +771,14 @@ Configuration Example
                         )
                     }
 
-                    $mockWikiContentOutput = "# MyResource
+                    $mockWikiContentOutput = '# MyResource
 
 ## Parameters
 
 | Parameter | Attribute | DataType | Description | Allowed Values |
 | --- | --- | --- | --- | --- |
 | **Id** | Key | String | Id Description | |
-| **Enum** | Write | String | Enum Description. | Value1, Value2, Value3 |
+| **Enum** | Write | String | Enum Description. | `Value1`, `Value2`, `Value3` |
 | **Int** | Required | Uint32 | Int Description. | |
 | **Read** | Read | String | Read Description. | |
 
@@ -750,7 +789,7 @@ Configuration Example
 | Parameter | Attribute | DataType | Description | Allowed Values |
 | --- | --- | --- | --- | --- |
 | **EmbeddedId** | Key | String | Id Description | |
-| **EmbeddedEnum** | Write | String | Enum Description. | Value1, Value2, Value3 |
+| **EmbeddedEnum** | Write | String | Enum Description. | `Value1`, `Value2`, `Value3` |
 | **EmbeddedInt** | Required | Uint32 | Int Description. | |
 | **EmbeddedRead** | Read | String | Read Description. | |
 
@@ -772,13 +811,13 @@ Configuration Example
     {
         MyResource Something
         {
-            Id    = 'MyId'
-            Enum  = 'Value1'
+            Id    = ''MyId''
+            Enum  = ''Value1''
             Int   = 1
         }
     }
 }
-" -replace '\r?\n', "`r`n"
+' -replace '\r?\n', "`r`n"
 
                     Mock `
                         -CommandName Get-ChildItem `
@@ -798,7 +837,14 @@ Configuration Example
                     Mock `
                         -CommandName Get-ChildItem `
                         -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                        -MockWith { return @(@{ Name = 'README.MD'; FullName = $script:mockReadmePath }) }
+                        -MockWith {
+                            return @(
+                                @{
+                                    Name = 'README.MD'
+                                    FullName = $script:mockReadmePath
+                                }
+                            )
+                        }
 
                     Mock `
                         -CommandName Get-Content `
@@ -835,8 +881,14 @@ Configuration Example
                     Assert-MockCalled `
                         -CommandName Out-File `
                         -ParameterFilter {
-                        $InputObject -eq $mockWikiContentOutput
-                    } `
+                            if ($InputObject -ne $mockWikiContentOutput)
+                            {
+                                # Helper to output the diff.
+                                Out-Diff -Expected $mockWikiContentOutput -Actual $InputObject
+                            }
+
+                            $InputObject -eq $mockWikiContentOutput
+                        } `
                         -Exactly -Times 1
                 }
 
@@ -1353,7 +1405,7 @@ class AzDevOpsProject
 | --- | --- | --- | --- | --- |
 | **ProjectName** | Key | System.String | ProjectName description. | |
 | **ProjectId** | Write | System.String | ProjectId description. Second row with text. | |
-| **ValidateSetProperty** | Write | System.String | | Up, Down |
+| **ValidateSetProperty** | Write | System.String | | `Up`, `Down` |
 | **MandatoryProperty** | Required | System.String | MandatoryProperty description. | |
 | **Reasons** | Read | String[] | Reasons description. | |
 

--- a/tests/unit/public/New-DscResourceWikiPage.Tests.ps1
+++ b/tests/unit/public/New-DscResourceWikiPage.Tests.ps1
@@ -18,6 +18,8 @@ Remove-Module -Name $script:moduleName -Force -ErrorAction 'SilentlyContinue'
 Import-Module $script:moduleName -Force -ErrorAction 'Stop'
 #endregion HEADER
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '../../helpers/DscResource.DocGenerator.TestHelper.psm1') -Force
+
 InModuleScope $script:moduleName {
     <#
         .NOTES
@@ -55,81 +57,82 @@ InModuleScope $script:moduleName {
     }
 
     Describe 'New-DscResourceWikiPage' {
-        $script:mockOutputPath = Join-Path -Path $TestDrive -ChildPath 'docs'
-        $script:mockDestinationModulePath = Join-Path -Path $TestDrive -ChildPath 'output\MyModule\1.0.0'
-        $script:mockModulePath = Join-Path -Path $TestDrive -ChildPath 'module'
+        Context 'When generating documentation for MOF-based resources' {
+            $script:mockOutputPath = Join-Path -Path $TestDrive -ChildPath 'docs'
+            $script:mockDestinationModulePath = Join-Path -Path $TestDrive -ChildPath 'output\MyModule\1.0.0'
+            $script:mockSourcePath = Join-Path -Path $TestDrive -ChildPath 'module'
 
-        # Schema file info
-        $script:mockResourceName = 'MyResource'
-        $script:expectedSchemaPath = Join-Path -Path $script:mockModulePath -ChildPath '\**\*.schema.mof'
-        $script:mockSchemaBaseName = "MSFT_$($script:mockResourceName).schema"
-        $script:mockSchemaFileName = "$($script:mockSchemaBaseName).mof"
-        $script:mockSchemaFolder = Join-Path -Path $script:mockModulePath -ChildPath "DSCResources\$($script:mockResourceName)"
-        $script:mockSchemaFilePath = Join-Path -Path $script:mockSchemaFolder -ChildPath $script:mockSchemaFileName
-        $script:mockSchemaFiles = @(
-            @{
-                FullName      = $script:mockSchemaFilePath
-                Name          = $script:mockSchemaFileName
-                DirectoryName = $script:mockSchemaFolder
-                BaseName      = $script:mockSchemaBaseName
-            }
-        )
-
-        $script:mockGetMofSchemaObject = @{
-            ClassName    = 'MSFT_MyResource'
-            Attributes   = @(
+            # Schema file info
+            $script:mockResourceName = 'MyResource'
+            $script:expectedSchemaPath = Join-Path -Path $script:mockSourcePath -ChildPath '\**\*.schema.mof'
+            $script:mockSchemaBaseName = "MSFT_$($script:mockResourceName).schema"
+            $script:mockSchemaFileName = "$($script:mockSchemaBaseName).mof"
+            $script:mockSchemaFolder = Join-Path -Path $script:mockSourcePath -ChildPath "DSCResources\$($script:mockResourceName)"
+            $script:mockSchemaFilePath = Join-Path -Path $script:mockSchemaFolder -ChildPath $script:mockSchemaFileName
+            $script:mockSchemaFiles = @(
                 @{
-                    State            = 'Key'
-                    DataType         = 'String'
-                    ValueMap         = @()
-                    IsArray          = $false
-                    Name             = 'Id'
-                    Description      = 'Id Description'
-                    EmbeddedInstance = ''
-                },
-                @{
-                    State            = 'Write'
-                    DataType         = 'String'
-                    ValueMap         = @( 'Value1', 'Value2', 'Value3' )
-                    IsArray          = $false
-                    Name             = 'Enum'
-                    Description      = 'Enum Description.'
-                    EmbeddedInstance = ''
-                },
-                @{
-                    State            = 'Required'
-                    DataType         = 'Uint32'
-                    ValueMap         = @()
-                    IsArray          = $false
-                    Name             = 'Int'
-                    Description      = 'Int Description.'
-                    EmbeddedInstance = ''
-                },
-                @{
-                    State            = 'Read'
-                    DataType         = 'String'
-                    ValueMap         = @()
-                    IsArray          = $false
-                    Name             = 'Read'
-                    Description      = 'Read Description.'
-                    EmbeddedInstance = ''
+                    FullName      = $script:mockSchemaFilePath
+                    Name          = $script:mockSchemaFileName
+                    DirectoryName = $script:mockSchemaFolder
+                    BaseName      = $script:mockSchemaBaseName
                 }
             )
-            ClassVersion = '1.0.0'
-            FriendlyName = 'MyResource'
-        }
 
-        # Example file info
-        $script:mockExampleFilePath = Join-Path -Path $script:mockModulePath -ChildPath "\Examples\Resources\$($script:mockResourceName)\$($script:mockResourceName)_Example1_Config.ps1"
-        $script:expectedExamplePath = Join-Path -Path $script:mockModulePath -ChildPath "\Examples\Resources\$($script:mockResourceName)\*.ps1"
-        $script:mockExampleFiles = @(
-            @{
-                Name      = "$($script:mockResourceName)_Example1_Config.ps1"
-                FullName  = $script:mockExampleFilePath
+            $script:mockGetMofSchemaObject = @{
+                ClassName    = 'MSFT_MyResource'
+                Attributes   = @(
+                    @{
+                        State            = 'Key'
+                        DataType         = 'String'
+                        ValueMap         = @()
+                        IsArray          = $false
+                        Name             = 'Id'
+                        Description      = 'Id Description'
+                        EmbeddedInstance = ''
+                    },
+                    @{
+                        State            = 'Write'
+                        DataType         = 'String'
+                        ValueMap         = @( 'Value1', 'Value2', 'Value3' )
+                        IsArray          = $false
+                        Name             = 'Enum'
+                        Description      = 'Enum Description.'
+                        EmbeddedInstance = ''
+                    },
+                    @{
+                        State            = 'Required'
+                        DataType         = 'Uint32'
+                        ValueMap         = @()
+                        IsArray          = $false
+                        Name             = 'Int'
+                        Description      = 'Int Description.'
+                        EmbeddedInstance = ''
+                    },
+                    @{
+                        State            = 'Read'
+                        DataType         = 'String'
+                        ValueMap         = @()
+                        IsArray          = $false
+                        Name             = 'Read'
+                        Description      = 'Read Description.'
+                        EmbeddedInstance = ''
+                    }
+                )
+                ClassVersion = '1.0.0'
+                FriendlyName = 'MyResource'
             }
-        )
 
-        $script:mockExampleContent = '.EXAMPLE 1
+            # Example file info
+            $script:mockExampleFilePath = Join-Path -Path $script:mockSourcePath -ChildPath "\Examples\Resources\$($script:mockResourceName)\$($script:mockResourceName)_Example1_Config.ps1"
+            $script:expectedExamplePath = Join-Path -Path $script:mockSourcePath -ChildPath "\Examples\Resources\$($script:mockResourceName)\*.ps1"
+            $script:mockExampleFiles = @(
+                @{
+                    Name     = "$($script:mockResourceName)_Example1_Config.ps1"
+                    FullName = $script:mockExampleFilePath
+                }
+            )
+
+            $script:mockExampleContent = '.EXAMPLE 1
 
 Example description.
 
@@ -147,13 +150,13 @@ Configuration Example
     }
 }'
 
-        # General mock values
-        $script:mockReadmePath = Join-Path -Path $script:mockSchemaFolder -ChildPath 'readme.md'
-        $script:mockReadmeFolder = $script:mockSchemaFolder
-        $script:mockOutputFile = Join-Path -Path $script:mockOutputPath -ChildPath "$($script:mockResourceName).md"
-        $script:mockSavePath = Join-Path -Path $script:mockOutputPath -ChildPath "$($script:mockResourceName).md"
-        $script:mockDestinationModulePathSavePath = Join-Path -Path $script:mockDestinationModulePath -ChildPath "DscResources\$($script:mockResourceName)\en-US\about_$($script:mockResourceName).help.txt"
-        $script:mockGetContentReadme = '# Description
+            # General mock values
+            $script:mockReadmePath = Join-Path -Path $script:mockSchemaFolder -ChildPath 'readme.md'
+            $script:mockReadmeFolder = $script:mockSchemaFolder
+            $script:mockOutputFile = Join-Path -Path $script:mockOutputPath -ChildPath "$($script:mockResourceName).md"
+            $script:mockSavePath = Join-Path -Path $script:mockOutputPath -ChildPath "$($script:mockResourceName).md"
+            $script:mockDestinationModulePathSavePath = Join-Path -Path $script:mockDestinationModulePath -ChildPath "DscResources\$($script:mockResourceName)\en-US\about_$($script:mockResourceName).help.txt"
+            $script:mockGetContentReadme = '# Description
 
 The description of the resource.
 Second row of description.
@@ -195,548 +198,549 @@ Configuration Example
 }
 " -replace '\r?\n', "`r`n"
 
-        # Parameter filters
-        $script:getChildItemSchema_parameterFilter = {
-            $Path -eq $script:expectedSchemaPath
-        }
-
-        $script:getChildItemDescription_parameterFilter = {
-            $Path -eq $script:mockReadmeFolder
-        }
-
-        $script:getChildItemExample_parameterFilter = {
-            $Path -eq $script:expectedExamplePath
-        }
-
-        $script:getMofSchemaObjectSchema_parameterFilter = {
-            $Filename -eq $script:mockSchemaFilePath
-        }
-
-        $script:getTestPathReadme_parameterFilter = {
-            $Path -eq $script:mockReadmePath
-        }
-
-        $script:getContentReadme_parameterFilter = {
-            $Path -eq $script:mockReadmePath
-        }
-
-        $script:getDscResourceWikiExampleContent_parameterFilter = {
-            $ExamplePath -eq $script:mockExampleFilePath -and $ExampleNumber -eq 1
-        }
-
-        $script:outFile_parameterFilter = {
-            $FilePath -eq $script:mockSavePath
-        }
-
-        $script:outFileInputObject_parameterFilter = {
-            $InputObject -eq $script:mockWikiContentOutput -and
-            $FilePath -eq $script:mockSavePath
-        }
-
-        $script:outFileOutputInputObject_parameterFilter = {
-            $InputObject -eq $script:mockWikiContentOutput -and
-            $FilePath -eq $script:mockSavePath
-        }
-
-        $script:writeWarningDescription_parameterFilter = {
-            $Message -eq ($script:localizedData.NoDescriptionFileFoundWarning -f $script:mockResourceName)
-        }
-
-        $script:writeWarningMultipleDescription_parameterFilter = {
-            $Message -eq ($script:localizedData.MultipleDescriptionFileFoundWarning -f $script:mockResourceName, 2)
-        }
-
-        $script:writeWarningExample_parameterFilter = {
-            $Message -eq ($script:localizedData.NoExampleFileFoundWarning -f $script:mockResourceName)
-        }
-
-        # Function call parameters
-        $script:newDscResourceWikiPage_parameters = @{
-            ModulePath = $script:mockModulePath
-            Verbose = $true
-        }
-
-        $script:newDscResourceWikiPageOutput_parameters = @{
-            ModulePath = $script:mockModulePath
-            OutputPath = $script:mockOutputPath
-            Verbose = $true
-        }
-
-        $script:newDscResourceWikiPageDestinationModulePath_parameters = @{
-            ModulePath = $script:mockModulePath
-            DestinationModulePath = $script:mockDestinationModulePath
-            Verbose = $true
-        }
-
-        Context 'When there are no schemas found in the module folder' {
-            BeforeAll {
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemSchema_parameterFilter
-
-                Mock `
-                    -CommandName Out-File `
-                    -ParameterFilter $script:outFile_parameterFilter
+            # Parameter filters
+            $script:getChildItemSchema_parameterFilter = {
+                $Path -eq $script:expectedSchemaPath
             }
 
-            It 'Should not throw an exception' {
-                { New-DscResourceWikiPage @script:newDscResourceWikiPageOutput_parameters } | Should -Not -Throw
+            $script:getChildItemDescription_parameterFilter = {
+                $Path -eq $script:mockReadmeFolder
             }
 
-            It 'Should call the expected mocks ' {
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemSchema_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Out-File `
-                    -Exactly -Times 0
-            }
-        }
-
-        Context 'When there is no resource description found' {
-            BeforeAll {
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemSchema_parameterFilter `
-                    -MockWith { $script:mockSchemaFiles }
-
-                Mock `
-                    -CommandName Get-MofSchemaObject `
-                    -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
-                    -MockWith { $script:mockGetMofSchemaObject }
-
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                    -MockWith { $null }
-
-                Mock `
-                    -CommandName Out-File `
-                    -ParameterFilter $script:outFile_parameterFilter
-
-                Mock `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningDescription_parameterFilter
+            $script:getChildItemExample_parameterFilter = {
+                $Path -eq $script:expectedExamplePath
             }
 
-            It 'Should not throw an exception' {
-                { New-DscResourceWikiPage @script:newDscResourceWikiPageOutput_parameters } | Should -Not -Throw
+            $script:getMofSchemaObjectSchema_parameterFilter = {
+                $Filename -eq $script:mockSchemaFilePath
             }
 
-            It 'Should call the expected mocks ' {
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemSchema_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningDescription_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Out-File `
-                    -ParameterFilter $script:outFile_parameterFilter `
-                    -Exactly -Times 0
-            }
-        }
-
-        Context 'When there are multiple resource descriptions found' {
-            BeforeAll {
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemSchema_parameterFilter `
-                    -MockWith { $script:mockSchemaFiles }
-
-                Mock `
-                    -CommandName Get-MofSchemaObject `
-                    -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
-                    -MockWith { $script:mockGetMofSchemaObject }
-
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                    -MockWith { return @(
-                                    @{ Name = 'README.MD'; FullName = $script:mockReadmePath },
-                                    @{ Name = 'Readme.md'; FullName = $script:mockReadmePath }) }
-
-                Mock `
-                    -CommandName Out-File `
-                    -ParameterFilter $script:outFile_parameterFilter
-
-                Mock `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningMultipleDescription_parameterFilter
+            $script:getTestPathReadme_parameterFilter = {
+                $Path -eq $script:mockReadmePath
             }
 
-            It 'Should not throw an exception' {
-                { New-DscResourceWikiPage @script:newDscResourceWikiPageOutput_parameters } | Should -Not -Throw
+            $script:getContentReadme_parameterFilter = {
+                $Path -eq $script:mockReadmePath
             }
 
-            It 'Should call the expected mocks ' {
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemSchema_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningMultipleDescription_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Out-File `
-                    -ParameterFilter $script:outFile_parameterFilter `
-                    -Exactly -Times 0
-            }
-        }
-
-        Context 'When there is no resource example file found' {
-            BeforeAll {
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemSchema_parameterFilter `
-                    -MockWith { $script:mockSchemaFiles }
-
-                Mock `
-                    -CommandName Get-MofSchemaObject `
-                    -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
-                    -MockWith { $script:mockGetMofSchemaObject }
-
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                    -MockWith { return @(@{ Name = 'README.MD'; FullName = $script:mockReadmePath }) }
-
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter $script:getContentReadme_parameterFilter `
-                    -MockWith { $script:mockGetContentReadme }
-
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemExample_parameterFilter
-
-                Mock `
-                    -CommandName Get-DscResourceWikiExampleContent
-
-                Mock `
-                    -CommandName Out-File `
-                    -ParameterFilter $script:outFile_parameterFilter
-
-                Mock `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningExample_parameterFilter
+            $script:getDscResourceWikiExampleContent_parameterFilter = {
+                $ExamplePath -eq $script:mockExampleFilePath -and $ExampleNumber -eq 1
             }
 
-            It 'Should not throw an exception' {
-                { New-DscResourceWikiPage @script:newDscResourceWikiPageOutput_parameters } | Should -Not -Throw
+            $script:outFile_parameterFilter = {
+                $FilePath -eq $script:mockSavePath
             }
 
-            It 'Should call the expected mocks ' {
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemSchema_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-Content `
-                    -ParameterFilter $script:getContentReadme_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemExample_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-DscResourceWikiExampleContent `
-                    -ParameterFilter $script:getDscResourceWikiExampleContent_parameterFilter `
-                    -Exactly -Times 0
-
-                Assert-MockCalled `
-                    -CommandName Out-File `
-                    -ParameterFilter $script:outFile_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningExample_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningDescription_parameterFilter `
-                    -Exactly -Times 0
-            }
-        }
-
-        Context 'When there is one schema found in the module folder and one example using .EXAMPLE and the OutputPath is specified' {
-            BeforeAll {
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemSchema_parameterFilter `
-                    -MockWith { $script:mockSchemaFiles }
-
-                Mock `
-                    -CommandName Get-MofSchemaObject `
-                    -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
-                    -MockWith { $script:mockGetMofSchemaObject }
-
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                    -MockWith { return @(@{ Name = 'README.MD'; FullName = $script:mockReadmePath }) }
-
-
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter $script:getContentReadme_parameterFilter `
-                    -MockWith { $script:mockGetContentReadme }
-
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemExample_parameterFilter `
-                    -MockWith { $script:mockExampleFiles }
-
-                Mock `
-                    -CommandName Get-DscResourceWikiExampleContent `
-                    -ParameterFilter $script:getDscResourceWikiExampleContent_parameterFilter `
-                    -MockWith { $script:mockExampleContent }
-
-                Mock `
-                    -CommandName Out-File
-
-                Mock `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningExample_parameterFilter
-
-                Mock `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningDescription_parameterFilter
+            $script:outFileInputObject_parameterFilter = {
+                $InputObject -eq $script:mockWikiContentOutput -and
+                $FilePath -eq $script:mockSavePath
             }
 
-            It 'Should not throw an exception' {
-                { New-DscResourceWikiPage @script:newDscResourceWikiPageOutput_parameters } | Should -Not -Throw
+            $script:outFileOutputInputObject_parameterFilter = {
+                $InputObject -eq $script:mockWikiContentOutput -and
+                $FilePath -eq $script:mockSavePath
             }
 
-            It 'Should produce the correct output' {
-                Assert-MockCalled `
-                    -CommandName Out-File `
-                    -ParameterFilter $script:outFileOutputInputObject_parameterFilter `
-                    -Exactly -Times 1
+            $script:writeWarningDescription_parameterFilter = {
+                $Message -eq ($script:localizedData.NoDescriptionFileFoundWarning -f $script:mockResourceName)
             }
 
-            It 'Should call the expected mocks ' {
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemSchema_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-MofSchemaObject `
-                    -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-Content `
-                    -ParameterFilter $script:getContentReadme_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemExample_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-DscResourceWikiExampleContent `
-                    -ParameterFilter $script:getDscResourceWikiExampleContent_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningExample_parameterFilter `
-                    -Exactly -Times 0
-
-                Assert-MockCalled `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningDescription_parameterFilter `
-                    -Exactly -Times 0
-            }
-        }
-
-        Context 'When there is one schema found in the module folder and one example using .EXAMPLE and only the parameter ModulePath is specified' {
-            BeforeAll {
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemSchema_parameterFilter `
-                    -MockWith { $script:mockSchemaFiles }
-
-                Mock `
-                    -CommandName Get-MofSchemaObject `
-                    -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
-                    -MockWith { $script:mockGetMofSchemaObject }
-
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                    -MockWith { return @(@{ Name = 'README.MD'; FullName = $script:mockReadmePath }) }
-
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter $script:getContentReadme_parameterFilter `
-                    -MockWith { $script:mockGetContentReadme }
-
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemExample_parameterFilter `
-                    -MockWith { $script:mockExampleFiles }
-
-                Mock `
-                    -CommandName Get-DscResourceWikiExampleContent `
-                    -ParameterFilter $script:getDscResourceWikiExampleContent_parameterFilter `
-                    -MockWith { $script:mockExampleContent }
-
-                Mock `
-                    -CommandName Out-File
-
-                Mock `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningExample_parameterFilter
-
-                Mock `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningDescription_parameterFilter
+            $script:writeWarningMultipleDescription_parameterFilter = {
+                $Message -eq ($script:localizedData.MultipleDescriptionFileFoundWarning -f $script:mockResourceName, 2)
             }
 
-            It 'Should not throw an exception' {
-                { New-DscResourceWikiPage @script:newDscResourceWikiPageOutput_parameters } | Should -Not -Throw
+            $script:writeWarningExample_parameterFilter = {
+                $Message -eq ($script:localizedData.NoExampleFileFoundWarning -f $script:mockResourceName)
             }
 
-            It 'Should produce the correct output' {
-                Assert-MockCalled `
-                    -CommandName Out-File `
-                    -ParameterFilter $script:outFileInputObject_parameterFilter `
-                    -Exactly -Times 1
+            # Function call parameters
+            $script:newDscResourceWikiPage_parameters = @{
+                SourcePath = $script:mockSourcePath
+                Verbose    = $true
             }
 
-            It 'Should call the expected mocks ' {
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemSchema_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-MofSchemaObject `
-                    -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-Content `
-                    -ParameterFilter $script:getContentReadme_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemExample_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Get-DscResourceWikiExampleContent `
-                    -ParameterFilter $script:getDscResourceWikiExampleContent_parameterFilter `
-                    -Exactly -Times 1
-
-                Assert-MockCalled `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningExample_parameterFilter `
-                    -Exactly -Times 0
-
-                Assert-MockCalled `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningDescription_parameterFilter `
-                    -Exactly -Times 0
+            $script:newDscResourceWikiPageOutput_parameters = @{
+                SourcePath      = $script:mockSourcePath
+                OutputPath      = $script:mockOutputPath
+                BuiltModulePath = '.' # Not used for MOF-based resources
+                Verbose         = $true
             }
-        }
 
-        Context 'When the schema is using an embedded instance' {
-            BeforeAll {
-                <#
-                    This is the mocked embedded schema that is to be returned
-                    together with the resource schema (which is mocked above)
-                    for the mocked function Get-MofSchemaObject.
-                #>
-                $script:mockEmbeddedSchemaObject = @{
-                    ClassName    = 'DSC_EmbeddedInstance'
-                    ClassVersion = '1.0.0'
-                    FriendlyName = 'EmbeddedInstance'
-                    Attributes   = @(
-                        @{
-                            State            = 'Key'
-                            DataType         = 'String'
-                            ValueMap         = @()
-                            IsArray          = $false
-                            Name             = 'EmbeddedId'
-                            Description      = 'Id Description'
-                            EmbeddedInstance = ''
-                        },
-                        @{
-                            State            = 'Write'
-                            DataType         = 'String'
-                            ValueMap         = @( 'Value1', 'Value2', 'Value3' )
-                            IsArray          = $false
-                            Name             = 'EmbeddedEnum'
-                            Description      = 'Enum Description.'
-                            EmbeddedInstance = ''
-                        },
-                        @{
-                            State            = 'Required'
-                            DataType         = 'Uint32'
-                            ValueMap         = @()
-                            IsArray          = $false
-                            Name             = 'EmbeddedInt'
-                            Description      = 'Int Description.'
-                            EmbeddedInstance = ''
-                        },
-                        @{
-                            State            = 'Read'
-                            DataType         = 'String'
-                            ValueMap         = @()
-                            IsArray          = $false
-                            Name             = 'EmbeddedRead'
-                            Description      = 'Read Description.'
-                            EmbeddedInstance = ''
-                        }
-                    )
+            $script:newDscResourceWikiPageDestinationModulePath_parameters = @{
+                SourcePath            = $script:mockSourcePath
+                DestinationModulePath = $script:mockDestinationModulePath
+                Verbose               = $true
+            }
+
+            Context 'When there are no schemas found in the module folder' {
+                BeforeAll {
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemSchema_parameterFilter
+
+                    Mock `
+                        -CommandName Out-File `
+                        -ParameterFilter $script:outFile_parameterFilter
                 }
 
-                $mockWikiContentOutput = "# MyResource
+                It 'Should not throw an exception' {
+                    { New-DscResourceWikiPage @script:newDscResourceWikiPageOutput_parameters } | Should -Not -Throw
+                }
+
+                It 'Should call the expected mocks ' {
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemSchema_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Out-File `
+                        -Exactly -Times 0
+                }
+            }
+
+            Context 'When there is no resource description found' {
+                BeforeAll {
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemSchema_parameterFilter `
+                        -MockWith { $script:mockSchemaFiles }
+
+                    Mock `
+                        -CommandName Get-MofSchemaObject `
+                        -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
+                        -MockWith { $script:mockGetMofSchemaObject }
+
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemDescription_parameterFilter `
+                        -MockWith { $null }
+
+                    Mock `
+                        -CommandName Out-File `
+                        -ParameterFilter $script:outFile_parameterFilter
+
+                    Mock `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningDescription_parameterFilter
+                }
+
+                It 'Should not throw an exception' {
+                    { New-DscResourceWikiPage @script:newDscResourceWikiPageOutput_parameters } | Should -Not -Throw
+                }
+
+                It 'Should call the expected mocks ' {
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemSchema_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemDescription_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningDescription_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Out-File `
+                        -ParameterFilter $script:outFile_parameterFilter `
+                        -Exactly -Times 0
+                }
+            }
+
+            Context 'When there are multiple resource descriptions found' {
+                BeforeAll {
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemSchema_parameterFilter `
+                        -MockWith { $script:mockSchemaFiles }
+
+                    Mock `
+                        -CommandName Get-MofSchemaObject `
+                        -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
+                        -MockWith { $script:mockGetMofSchemaObject }
+
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemDescription_parameterFilter `
+                        -MockWith { return @(
+                            @{ Name = 'README.MD'; FullName = $script:mockReadmePath },
+                            @{ Name = 'Readme.md'; FullName = $script:mockReadmePath }) }
+
+                    Mock `
+                        -CommandName Out-File `
+                        -ParameterFilter $script:outFile_parameterFilter
+
+                    Mock `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningMultipleDescription_parameterFilter
+                }
+
+                It 'Should not throw an exception' {
+                    { New-DscResourceWikiPage @script:newDscResourceWikiPageOutput_parameters } | Should -Not -Throw
+                }
+
+                It 'Should call the expected mocks ' {
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemSchema_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemDescription_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningMultipleDescription_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Out-File `
+                        -ParameterFilter $script:outFile_parameterFilter `
+                        -Exactly -Times 0
+                }
+            }
+
+            Context 'When there is no resource example file found' {
+                BeforeAll {
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemSchema_parameterFilter `
+                        -MockWith { $script:mockSchemaFiles }
+
+                    Mock `
+                        -CommandName Get-MofSchemaObject `
+                        -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
+                        -MockWith { $script:mockGetMofSchemaObject }
+
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemDescription_parameterFilter `
+                        -MockWith { return @(@{ Name = 'README.MD'; FullName = $script:mockReadmePath }) }
+
+                    Mock `
+                        -CommandName Get-Content `
+                        -ParameterFilter $script:getContentReadme_parameterFilter `
+                        -MockWith { $script:mockGetContentReadme }
+
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemExample_parameterFilter
+
+                    Mock `
+                        -CommandName Get-DscResourceWikiExampleContent
+
+                    Mock `
+                        -CommandName Out-File `
+                        -ParameterFilter $script:outFile_parameterFilter
+
+                    Mock `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningExample_parameterFilter
+                }
+
+                It 'Should not throw an exception' {
+                    { New-DscResourceWikiPage @script:newDscResourceWikiPageOutput_parameters } | Should -Not -Throw
+                }
+
+                It 'Should call the expected mocks ' {
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemSchema_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemDescription_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-Content `
+                        -ParameterFilter $script:getContentReadme_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemExample_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-DscResourceWikiExampleContent `
+                        -ParameterFilter $script:getDscResourceWikiExampleContent_parameterFilter `
+                        -Exactly -Times 0
+
+                    Assert-MockCalled `
+                        -CommandName Out-File `
+                        -ParameterFilter $script:outFile_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningExample_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningDescription_parameterFilter `
+                        -Exactly -Times 0
+                }
+            }
+
+            Context 'When there is one schema found in the module folder and one example using .EXAMPLE and the OutputPath is specified' {
+                BeforeAll {
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemSchema_parameterFilter `
+                        -MockWith { $script:mockSchemaFiles }
+
+                    Mock `
+                        -CommandName Get-MofSchemaObject `
+                        -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
+                        -MockWith { $script:mockGetMofSchemaObject }
+
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemDescription_parameterFilter `
+                        -MockWith { return @(@{ Name = 'README.MD'; FullName = $script:mockReadmePath }) }
+
+
+                    Mock `
+                        -CommandName Get-Content `
+                        -ParameterFilter $script:getContentReadme_parameterFilter `
+                        -MockWith { $script:mockGetContentReadme }
+
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemExample_parameterFilter `
+                        -MockWith { $script:mockExampleFiles }
+
+                    Mock `
+                        -CommandName Get-DscResourceWikiExampleContent `
+                        -ParameterFilter $script:getDscResourceWikiExampleContent_parameterFilter `
+                        -MockWith { $script:mockExampleContent }
+
+                    Mock `
+                        -CommandName Out-File
+
+                    Mock `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningExample_parameterFilter
+
+                    Mock `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningDescription_parameterFilter
+                }
+
+                It 'Should not throw an exception' {
+                    { New-DscResourceWikiPage @script:newDscResourceWikiPageOutput_parameters } | Should -Not -Throw
+                }
+
+                It 'Should produce the correct output' {
+                    Assert-MockCalled `
+                        -CommandName Out-File `
+                        -ParameterFilter $script:outFileOutputInputObject_parameterFilter `
+                        -Exactly -Times 1
+                }
+
+                It 'Should call the expected mocks ' {
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemSchema_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-MofSchemaObject `
+                        -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemDescription_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-Content `
+                        -ParameterFilter $script:getContentReadme_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemExample_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-DscResourceWikiExampleContent `
+                        -ParameterFilter $script:getDscResourceWikiExampleContent_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningExample_parameterFilter `
+                        -Exactly -Times 0
+
+                    Assert-MockCalled `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningDescription_parameterFilter `
+                        -Exactly -Times 0
+                }
+            }
+
+            Context 'When there is one schema found in the module folder and one example using .EXAMPLE and only the parameter SourcePath is specified' {
+                BeforeAll {
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemSchema_parameterFilter `
+                        -MockWith { $script:mockSchemaFiles }
+
+                    Mock `
+                        -CommandName Get-MofSchemaObject `
+                        -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
+                        -MockWith { $script:mockGetMofSchemaObject }
+
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemDescription_parameterFilter `
+                        -MockWith { return @(@{ Name = 'README.MD'; FullName = $script:mockReadmePath }) }
+
+                    Mock `
+                        -CommandName Get-Content `
+                        -ParameterFilter $script:getContentReadme_parameterFilter `
+                        -MockWith { $script:mockGetContentReadme }
+
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemExample_parameterFilter `
+                        -MockWith { $script:mockExampleFiles }
+
+                    Mock `
+                        -CommandName Get-DscResourceWikiExampleContent `
+                        -ParameterFilter $script:getDscResourceWikiExampleContent_parameterFilter `
+                        -MockWith { $script:mockExampleContent }
+
+                    Mock `
+                        -CommandName Out-File
+
+                    Mock `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningExample_parameterFilter
+
+                    Mock `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningDescription_parameterFilter
+                }
+
+                It 'Should not throw an exception' {
+                    { New-DscResourceWikiPage @script:newDscResourceWikiPageOutput_parameters } | Should -Not -Throw
+                }
+
+                It 'Should produce the correct output' {
+                    Assert-MockCalled `
+                        -CommandName Out-File `
+                        -ParameterFilter $script:outFileInputObject_parameterFilter `
+                        -Exactly -Times 1
+                }
+
+                It 'Should call the expected mocks ' {
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemSchema_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-MofSchemaObject `
+                        -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemDescription_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-Content `
+                        -ParameterFilter $script:getContentReadme_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemExample_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-DscResourceWikiExampleContent `
+                        -ParameterFilter $script:getDscResourceWikiExampleContent_parameterFilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningExample_parameterFilter `
+                        -Exactly -Times 0
+
+                    Assert-MockCalled `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningDescription_parameterFilter `
+                        -Exactly -Times 0
+                }
+            }
+
+            Context 'When the schema is using an embedded instance' {
+                BeforeAll {
+                    <#
+                        This is the mocked embedded schema that is to be returned
+                        together with the resource schema (which is mocked above)
+                        for the mocked function Get-MofSchemaObject.
+                    #>
+                    $script:mockEmbeddedSchemaObject = @{
+                        ClassName    = 'DSC_EmbeddedInstance'
+                        ClassVersion = '1.0.0'
+                        FriendlyName = 'EmbeddedInstance'
+                        Attributes   = @(
+                            @{
+                                State            = 'Key'
+                                DataType         = 'String'
+                                ValueMap         = @()
+                                IsArray          = $false
+                                Name             = 'EmbeddedId'
+                                Description      = 'Id Description'
+                                EmbeddedInstance = ''
+                            },
+                            @{
+                                State            = 'Write'
+                                DataType         = 'String'
+                                ValueMap         = @( 'Value1', 'Value2', 'Value3' )
+                                IsArray          = $false
+                                Name             = 'EmbeddedEnum'
+                                Description      = 'Enum Description.'
+                                EmbeddedInstance = ''
+                            },
+                            @{
+                                State            = 'Required'
+                                DataType         = 'Uint32'
+                                ValueMap         = @()
+                                IsArray          = $false
+                                Name             = 'EmbeddedInt'
+                                Description      = 'Int Description.'
+                                EmbeddedInstance = ''
+                            },
+                            @{
+                                State            = 'Read'
+                                DataType         = 'String'
+                                ValueMap         = @()
+                                IsArray          = $false
+                                Name             = 'EmbeddedRead'
+                                Description      = 'Read Description.'
+                                EmbeddedInstance = ''
+                            }
+                        )
+                    }
+
+                    $mockWikiContentOutput = "# MyResource
 
 ## Parameters
 
@@ -784,106 +788,107 @@ Configuration Example
 }
 " -replace '\r?\n', "`r`n"
 
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemSchema_parameterFilter `
-                    -MockWith { $script:mockSchemaFiles }
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemSchema_parameterFilter `
+                        -MockWith { $script:mockSchemaFiles }
 
-                Mock `
-                    -CommandName Get-MofSchemaObject `
-                    -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
-                    -MockWith {
+                    Mock `
+                        -CommandName Get-MofSchemaObject `
+                        -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
+                        -MockWith {
                         return @(
                             $script:mockGetMofSchemaObject
                             $script:mockEmbeddedSchemaObject
                         )
                     }
 
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                    -MockWith { return @(@{ Name = 'README.MD'; FullName = $script:mockReadmePath }) }
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemDescription_parameterFilter `
+                        -MockWith { return @(@{ Name = 'README.MD'; FullName = $script:mockReadmePath }) }
 
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter $script:getContentReadme_parameterFilter `
-                    -MockWith { $script:mockGetContentReadme }
+                    Mock `
+                        -CommandName Get-Content `
+                        -ParameterFilter $script:getContentReadme_parameterFilter `
+                        -MockWith { $script:mockGetContentReadme }
 
-                Mock `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemExample_parameterFilter `
-                    -MockWith { $script:mockExampleFiles }
+                    Mock `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemExample_parameterFilter `
+                        -MockWith { $script:mockExampleFiles }
 
-                Mock `
-                    -CommandName Get-DscResourceWikiExampleContent `
-                    -ParameterFilter $script:getDscResourceWikiExampleContent_parameterFilter `
-                    -MockWith { $script:mockExampleContent }
+                    Mock `
+                        -CommandName Get-DscResourceWikiExampleContent `
+                        -ParameterFilter $script:getDscResourceWikiExampleContent_parameterFilter `
+                        -MockWith { $script:mockExampleContent }
 
-                Mock `
-                    -CommandName Out-File
+                    Mock `
+                        -CommandName Out-File
 
-                Mock `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningExample_parameterFilter
+                    Mock `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningExample_parameterFilter
 
-                Mock `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningDescription_parameterFilter
-            }
+                    Mock `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningDescription_parameterFilter
+                }
 
-            It 'Should not throw an exception' {
-                { New-DscResourceWikiPage @script:newDscResourceWikiPageOutput_parameters } | Should -Not -Throw
-            }
+                It 'Should not throw an exception' {
+                    { New-DscResourceWikiPage @script:newDscResourceWikiPageOutput_parameters } | Should -Not -Throw
+                }
 
-            It 'Should produce the correct output' {
-                Assert-MockCalled `
-                    -CommandName Out-File `
-                    -ParameterFilter {
+                It 'Should produce the correct output' {
+                    Assert-MockCalled `
+                        -CommandName Out-File `
+                        -ParameterFilter {
                         $InputObject -eq $mockWikiContentOutput
                     } `
-                    -Exactly -Times 1
-            }
+                        -Exactly -Times 1
+                }
 
-            It 'Should call the expected mocks ' {
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemSchema_parameterFilter `
-                    -Exactly -Times 1
+                It 'Should call the expected mocks ' {
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemSchema_parameterFilter `
+                        -Exactly -Times 1
 
-                Assert-MockCalled `
-                    -CommandName Get-MofSchemaObject `
-                    -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
-                    -Exactly -Times 1
+                    Assert-MockCalled `
+                        -CommandName Get-MofSchemaObject `
+                        -ParameterFilter $script:getMofSchemaObjectSchema_parameterFilter `
+                        -Exactly -Times 1
 
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemDescription_parameterFilter `
-                    -Exactly -Times 1
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemDescription_parameterFilter `
+                        -Exactly -Times 1
 
-                Assert-MockCalled `
-                    -CommandName Get-Content `
-                    -ParameterFilter $script:getContentReadme_parameterFilter `
-                    -Exactly -Times 1
+                    Assert-MockCalled `
+                        -CommandName Get-Content `
+                        -ParameterFilter $script:getContentReadme_parameterFilter `
+                        -Exactly -Times 1
 
-                Assert-MockCalled `
-                    -CommandName Get-ChildItem `
-                    -ParameterFilter $script:getChildItemExample_parameterFilter `
-                    -Exactly -Times 1
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $script:getChildItemExample_parameterFilter `
+                        -Exactly -Times 1
 
-                Assert-MockCalled `
-                    -CommandName Get-DscResourceWikiExampleContent `
-                    -ParameterFilter $script:getDscResourceWikiExampleContent_parameterFilter `
-                    -Exactly -Times 1
+                    Assert-MockCalled `
+                        -CommandName Get-DscResourceWikiExampleContent `
+                        -ParameterFilter $script:getDscResourceWikiExampleContent_parameterFilter `
+                        -Exactly -Times 1
 
-                Assert-MockCalled `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningExample_parameterFilter `
-                    -Exactly -Times 0
+                    Assert-MockCalled `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningExample_parameterFilter `
+                        -Exactly -Times 0
 
-                Assert-MockCalled `
-                    -CommandName Write-Warning `
-                    -ParameterFilter $script:writeWarningDescription_parameterFilter `
-                    -Exactly -Times 0
+                    Assert-MockCalled `
+                        -CommandName Write-Warning `
+                        -ParameterFilter $script:writeWarningDescription_parameterFilter `
+                        -Exactly -Times 0
+                }
             }
         }
     }


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

The breaking change is in the public command `New-DscResourceWikiPage`. To support class-based resource the parameters were renamed to better recognize what path goes where.

I have tested this change on AzureDevOpsDsc and SqlServerDsc and both generate wiki documentation as expected.

### Added

- Added a new private function `Get-ClassResourceCommentBasedHelp` to get
  comment-based help from a PowerShell script file.
- Added a new private function `Get-ClassResourcePropertyState` to get
  named attribute argument (from the attribute `[DscProperty()]`) for a
  class-based resource parameter and return the corresponding name used by
  MOF-based resources.
- Added a new private function `Get-ResourceExampleAsMarkdown` that helps
  to return examples as markdown, and to reduce code duplication.
- Added a test helper module `DscResource.DocGenerator.TestHelper.psm1`
  that contain helper functions for tests.
  - Added helper function `Out-Diff` that outputs two text strings in hex
    side-by-side (thanks to @johanringman for help with this one).

### Changed

- `Split-ModuleVersion`
  - This cmdlet is now exported as a public function because it is required
    by the build task `Generate_Wiki_Content`.
- `Generate_Wiki_Content`
  - The Build task `Generate_Wiki_Content` was changed to call the cmdlet
    `New-DscResourceWikiPage` with the correct parameters to support generating
    documentation for class-based resource ([issue #52](https://github.com/dsccommunity/DscResource.DocGenerator/issues/52)).
- `New-DscResourceWikiPage`
  - Now supports generating wiki documentation for class-based resources
    ([issue #52](https://github.com/dsccommunity/DscResource.DocGenerator/issues/52)).
  - **BREAKING CHANGE:** To support class-based resource the parameters were
    renamed to better recognize what path goes where.
  - Each values that are in a `ValueMap` of a MOF schema parameter, or in
    a `ValidateSet()` of a class-based resource parameter, will be outputted
    as markdown inline code.

### Fixed

- `Get-ResourceExampleAsText`
  - Comment-based help was updated to reflect the correct parameters.
- `New-DscResourcePowerShellHelp`
  - Fixed unit tests to support new private function `Get-ClassResourceCommentBasedHelp`
    and use the test helper module `DscResource.DocGenerator.TestHelper.psm1`.
  - It no longer uses `Recurse` when looking for the module's PowerShell
    script files. It could potentially lead to that it found resources that
    are part of common modules in the `Modules` folder.
  - Made use of private functions to reduce duplicate code.
- `Get-DscResourceSchemaPropertyContent`
  - Fixed the private function so that the description property no longer
    output an extra whitespace in some circumstance

## This Pull Request (PR) fixes the following issues

- Fixes #52

## Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Documentation added/updated in README.md.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (where possible).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.docgenerator/59)
<!-- Reviewable:end -->
