### PR TITLE
`Invoke-Git`: Fix new line in returned strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enabled the function to extract the comment block if it is not at the top
     of the script file to support composite resources.
 - Updated code to pass newly added quality checks.
-- `Invoke-Git` 
+- `Invoke-Git`
   - Converted to public function.
   - Updated to use `System.Diagnostics.Process` for improved error handling.
   - Returns object, allowing caller to process result.
   - `git` commands no longer use `--quiet` to populate returned object.
+  - No longer write a new line to the end of string for the returned properties
+    `StandardOutput` and `StandardError`.
 
 ### Fixed
 

--- a/source/Public/Invoke-Git.ps1
+++ b/source/Public/Invoke-Git.ps1
@@ -79,6 +79,10 @@ function Invoke-Git
                 $returnValue.ExitCode = $process.ExitCode
                 $returnValue.StandardOutput = $process.StandardOutput.ReadToEnd()
                 $returnValue.StandardError = $process.StandardError.ReadToEnd()
+
+                # Remove all new lines at end of string.
+                $returnValue.StandardOutput = $returnValue.StandardOutput -replace '[\r?\n]+$'
+                $returnValue.StandardError = $returnValue.StandardError -replace '[\r?\n]+$'
             }
         }
     }


### PR DESCRIPTION
# Pull Request

### Pull Request (PR) description
- `Invoke-Git`
  - No longer write a new line to the end of string for the returned properties
    `StandardOutput` and `StandardError`.

#### This Pull Request (PR) fixes the following issues
Possibly #84 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [ ] Integration tests added/updated (where possible).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.docgenerator/94)
<!-- Reviewable:end -->
