### PR TITLE
`Get-ClassResourceProperty`: No longer throws exception for missing source file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Regression tests for PR #123.
   - Now longer throws an exception if a parent class that isn't part of the
     module is being used. If a class's source file is not found the class
-    is skipped.
+    is skipped (fixes [issue #127](https://github.com/dsccommunity/DscResource.DocGenerator/issues/127)).
 
 ## [0.11.1] - 2022-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Get-ClassResourceProperty`
   - Regression tests for PR #123.
+  - Now longer throws an exception if a parent class that isn't part of the
+    module is being used. If a class's source file is not found the class
+    is skipped.
 
 ## [0.11.1] - 2022-08-09
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,7 +151,7 @@ stages:
     - job: test_linux
       displayName: 'Unit Linux'
       pool:
-        vmImage: 'ubuntu-latest'
+        vmImage: 'ubuntu-20.04'
       timeoutInMinutes: 0
       steps:
         - task: DownloadPipelineArtifact@2

--- a/source/Private/Get-ClassResourceProperty.ps1
+++ b/source/Private/Get-ClassResourceProperty.ps1
@@ -46,6 +46,15 @@ function Get-ClassResourceProperty
 
         $sourceFilePath = Join-Path -Path $SourcePath -ChildPath ('Classes/???.{0}.ps1' -f $currentClassName)
 
+        <#
+            Skip if the class's source file does not exist. Thi can happen if the
+            class uses a parent class from a different module.
+        #>
+        if (-not (Test-Path -Path $sourceFilePath))
+        {
+            continue
+        }
+
         $dscResourceCommentBasedHelp = Get-CommentBasedHelp -Path $sourceFilePath
 
         $astFilter = {


### PR DESCRIPTION
#### Pull Request (PR) description

- `Get-ClassResourceProperty`
  - Now longer throws an exception if a parent class that isn't part of the
    module is being used. If a class's source file is not found the class
    is skipped (issue #127).

#### This Pull Request (PR) fixes the following issues

- Fixes #127

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.docgenerator/128)
<!-- Reviewable:end -->
