### PR TITLE
Fix tasks that fail for modules without exported commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `Generate_Markdown_For_Public_Commands.build`
+  - Now the task will not try to generate markdown if the module does not
+    have any publicly exported commands ([issue #135](https://github.com/dsccommunity/DscResource.DocGenerator/issues/147)).
+  - Now has error handling if the script that is called using the call
+    operator `&` fails.
+`Generate_External_Help_File_For_Public_Commands`
+  - Now the task will not fail if there are no extern help file generated,
+    which is the case for modules that does not have any publicly exported
+    commands ([issue #135](https://github.com/dsccommunity/DscResource.DocGenerator/issues/147)).
+  - Now has error handling if the script that is called using the call
+    operator `&` fails.
+
 ## [0.12.2] - 2024-05-31
 
 ### Added

--- a/source/tasks/Generate_External_Help_File_For_Public_Commands.build.ps1
+++ b/source/tasks/Generate_External_Help_File_For_Public_Commands.build.ps1
@@ -116,22 +116,19 @@ New-ExternalHelp -Path '$DocOutputFolder' -OutputPath '$builtModuleLocalePath' -
     #>
     & $pwshPath -Command $generateMarkdownScriptBlock -ExecutionPolicy 'ByPass' -NoProfile
 
-
     if (-not $?)
     {
         throw "Failed to generate external help file for the module '$ProjectName'."
     }
-    else
-    {
-        Write-Build -Color 'Green' -Text "External help file generated for the module '$ProjectName'."
-    }
 
-    $externalHelpFile = Get-Item -Path "$builtModuleLocalePath/$ProjectName-help.xml" -ErrorAction 'Ignore'
+    $externalHelpFile = Get-Item -Path (Join-Path -Path $builtModuleLocalePath -ChildPath "$ProjectName-help.xml") -ErrorAction 'Ignore'
 
     if ($externalHelpFile)
     {
         # Add a newline to the end of the help file to pass HQRM tests.
-        Add-NewLine -FileInfo (Get-Item -Path "$builtModuleLocalePath/$ProjectName-help.xml") -AtEndOfFile
+        Add-NewLine -FileInfo $externalHelpFile -AtEndOfFile
+
+        Write-Build -Color 'Green' -Text "External help file generated for the module '$ProjectName'."
     }
     else
     {

--- a/source/tasks/Generate_External_Help_File_For_Public_Commands.build.ps1
+++ b/source/tasks/Generate_External_Help_File_For_Public_Commands.build.ps1
@@ -116,6 +116,25 @@ New-ExternalHelp -Path '$DocOutputFolder' -OutputPath '$builtModuleLocalePath' -
     #>
     & $pwshPath -Command $generateMarkdownScriptBlock -ExecutionPolicy 'ByPass' -NoProfile
 
-    # Add a newline to the end of the help file to pass HQRM tests.
-    Add-NewLine -FileInfo (Get-Item -Path "$builtModuleLocalePath/$ProjectName-help.xml") -AtEndOfFile
+
+    if (-not $?)
+    {
+        throw "Failed to generate external help file for the module '$ProjectName'."
+    }
+    else
+    {
+        Write-Build -Color 'Green' -Text "External help file generated for the module '$ProjectName'."
+    }
+
+    $externalHelpFile = Get-Item -Path "$builtModuleLocalePath/$ProjectName-help.xml" -ErrorAction 'Ignore'
+
+    if ($externalHelpFile)
+    {
+        # Add a newline to the end of the help file to pass HQRM tests.
+        Add-NewLine -FileInfo (Get-Item -Path "$builtModuleLocalePath/$ProjectName-help.xml") -AtEndOfFile
+    }
+    else
+    {
+        Write-Warning -Message "External help file not found at '$builtModuleLocalePath/$ProjectName-help.xml'. This is normal if there were no exported commands in the module."
+    }
 }


### PR DESCRIPTION

#### Pull Request (PR) description

- `Generate_Markdown_For_Public_Commands.build`
  - Now the task will not try to generate markdown if the module does not
    have any publicly exported commands ([issue #135](https://github.com/dsccommunity/DscResource.DocGenerator/issues/147)).
  - Now has error handling if the script that is called using the call
    operator `&` fails.
`Generate_External_Help_File_For_Public_Commands`
  - Now the task will not fail if there are no extern help file generated,
    which is the case for modules that does not have any publicly exported
    commands ([issue #135](https://github.com/dsccommunity/DscResource.DocGenerator/issues/147)).
  - Now has error handling if the script that is called using the call
    operator `&` fails.

#### This Pull Request (PR) fixes the following issues

- Fixes #147

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DscResource.DocGenerator/148)
<!-- Reviewable:end -->
